### PR TITLE
remove the params model concept

### DIFF
--- a/src/auto_load.cpp
+++ b/src/auto_load.cpp
@@ -116,8 +116,6 @@ auto_load::auto_load(lt::session& s, save_settings_interface* sett)
 	, m_abort(false)
 	, m_thread(std::bind(&auto_load::thread_fun, this))
 {
-	m_params_model.save_path = ".";
-
 	if (m_settings)
 	{
 		int const interval = m_settings->get_int("autoload_interval", -1);
@@ -126,7 +124,6 @@ auto_load::auto_load(lt::session& s, save_settings_interface* sett)
 		if (!path.empty()) set_auto_load_dir(path);
 		int remove_files = m_settings->get_int("autoload_remove", -1);
 		if (remove_files != -1) set_remove_files(remove_files);
-		m_params_model.save_path = m_settings->get_str("save_path", ".");
 	}
 }
 
@@ -150,18 +147,6 @@ bool auto_load::remove_files() const
 {
 	std::unique_lock<std::mutex> l(m_mutex);
 	return m_remove_files;
-}
-
-void auto_load::set_params_model(lt::add_torrent_params const& p)
-{
-	std::unique_lock<std::mutex> l(m_mutex);
-	m_params_model = p;
-}
-
-lt::add_torrent_params auto_load::params_model() const
-{
-	std::unique_lock<std::mutex> l(m_mutex);
-	return m_params_model;
 }
 
 void auto_load::set_auto_load_dir(std::string const& dir)
@@ -221,7 +206,7 @@ void auto_load::on_scan(lt::error_code const& e)
 
 	// interval of 0 means disabled
 	if (m_scan_interval == std::chrono::seconds(0)) return;
-	
+
 	std::string path = m_dir;
 	bool remove_files = m_remove_files;
 	l.unlock();
@@ -250,10 +235,12 @@ void auto_load::on_scan(lt::error_code const& e)
 		// assume the file isn't fully written yet.
 		if (tec) continue;
 
-		l.lock();
-		lt::add_torrent_params p = m_params_model;
-		l.unlock();
-
+		lt::add_torrent_params p;
+		p.save_path = m_settings ? m_settings->get_str("save_path", "./downloads") : "./downloads";
+		if (m_settings && m_settings->get_int("start_paused", 0))
+			p.flags = (p.flags & ~lt::torrent_flags::auto_managed) | lt::torrent_flags::paused;
+		else
+			p.flags = (p.flags & ~lt::torrent_flags::paused) | lt::torrent_flags::auto_managed;
 		p.ti = ti;
 		m_ses.async_add_torrent(p);
 

--- a/src/auto_load.hpp
+++ b/src/auto_load.hpp
@@ -49,9 +49,6 @@ namespace ltweb
 		auto_load(lt::session& s, save_settings_interface* sett = NULL);
 		~auto_load();
 
-		void set_params_model(lt::add_torrent_params const& p);
-		lt::add_torrent_params params_model() const;
-
 		void set_auto_load_dir(std::string const& dir);
 		std::string const& auto_load_dir() const { return m_dir; }
 
@@ -81,13 +78,12 @@ namespace ltweb
 		// add them again
 		std::set<std::string> m_already_loaded;
 
-		lt::add_torrent_params m_params_model;
 		std::string m_dir;
 		std::chrono::seconds m_scan_interval;
 		bool m_abort;
 
-		// used to protect m_abort, m_scan_interval, m_dir,
-		// m_remove_files and m_params_model
+		// used to protect m_abort, m_scan_interval, m_dir
+		// and m_remove_files
 		mutable std::mutex m_mutex;
 
 		// this needs to be last in order to be initialized

--- a/src/libtorrent_webui.cpp
+++ b/src/libtorrent_webui.cpp
@@ -43,6 +43,7 @@ POSSIBILITY OF SUCH DAMAGE.
 #include "libtorrent/magnet_uri.hpp"
 
 #include "auth.hpp"
+#include "save_settings.hpp"
 #include "torrent_history.hpp"
 #include "websocket_conn.hpp"
 
@@ -228,13 +229,14 @@ namespace {
 	};
 
 	libtorrent_webui::libtorrent_webui(lt::session& ses, torrent_history const* hist
-		, auth_interface const* auth, alert_handler* alert)
+		, auth_interface const* auth, alert_handler* alert
+		, save_settings_interface* sett)
 		: m_ses(ses)
 		, m_hist(hist)
 		, m_auth(auth)
 		, m_alert(alert)
+		, m_settings(sett)
 	{
-		m_params_model.save_path = ".";
 
 		if (m_stats.size() < lt::counters::num_counters)
 			m_stats.resize(lt::counters::num_counters
@@ -1025,13 +1027,17 @@ namespace {
 
 		lt::string_view magnet_link(iptr, magnet_len);
 
-		lt::add_torrent_params atp = m_params_model;
+		lt::add_torrent_params atp;
 
 		lt::error_code ec;
 		lt::parse_magnet_uri(magnet_link, atp, ec);
 		if (ec) return error(st, f, parse_error);
 
-		atp.save_path = m_params_model.save_path;
+		atp.save_path = m_settings ? m_settings->get_str("save_path", "./downloads") : "./downloads";
+		if (m_settings && m_settings->get_int("start_paused", 0))
+			atp.flags = (atp.flags & ~lt::torrent_flags::auto_managed) | lt::torrent_flags::paused;
+		else
+			atp.flags = (atp.flags & ~lt::torrent_flags::paused) | lt::torrent_flags::auto_managed;
 		atp.flags |= lt::torrent_flags::duplicate_is_error;
 
 		atp.userdata = new add_torrent_user_data{st->shared_from_this()
@@ -1051,7 +1057,6 @@ namespace {
 		return functions[function_id].name;
 	}
 
-	// TODO: this should take a span
 	bool libtorrent_webui::on_websocket_read(websocket_conn* st, lt::span<char const> data)
 	{
 		// parse RPC message

--- a/src/libtorrent_webui.hpp
+++ b/src/libtorrent_webui.hpp
@@ -55,17 +55,16 @@ namespace ltweb
 	struct auth_interface;
 	struct alert_handler;
 	struct websocket_conn;
+	struct save_settings_interface;
 
 	struct function_call;
 
 	struct libtorrent_webui : http_handler, alert_observer
 	{
 		libtorrent_webui(lt::session& ses, torrent_history const* hist
-			, auth_interface const* auth, alert_handler* alerts);
+			, auth_interface const* auth, alert_handler* alerts
+			, save_settings_interface* sett = nullptr);
 		~libtorrent_webui();
-
-		void set_params_model(lt::add_torrent_params const& p)
-		{ m_params_model = p; }
 
 		// internal
 		bool get_torrent_updates(websocket_conn* st, function_call f);
@@ -115,6 +114,7 @@ namespace ltweb
 		torrent_history const* m_hist;
 		auth_interface const* m_auth;
 		alert_handler* m_alert;
+		save_settings_interface* m_settings;
 
 		std::mutex m_stats_mutex;
 		// TODO: factor this out into its own class
@@ -123,8 +123,6 @@ namespace ltweb
 		// the current stats frame (incremented every time) stats
 		// are requested
 		frame_t m_stats_frame = 0;
-
-		lt::add_torrent_params m_params_model;
 	};
 }
 

--- a/src/save_resume.cpp
+++ b/src/save_resume.cpp
@@ -293,17 +293,18 @@ bool save_resume::ok_to_quit() const
 	return m_num_in_flight == 0;
 }
 
-void save_resume::load(lt::error_code& ec, lt::add_torrent_params model)
+void save_resume::load(lt::error_code& ec)
 {
+	ec.clear();
 	sqlite3_stmt* stmt = nullptr;
 	int ret = sqlite3_prepare_v2(m_db, "SELECT RESUME FROM TORRENTS;", -1, &stmt, nullptr);
 	if (ret != SQLITE_OK)
 	{
+		// TODO: improve error reporting
 		fprintf(stderr, "failed to prepare select statement: %s\n", sqlite3_errmsg(m_db));
 		return;
 	}
 
-	lt::add_torrent_params p = model;
 	ret = sqlite3_step(stmt);
 	while (ret == SQLITE_ROW)
 	{
@@ -312,15 +313,16 @@ void save_resume::load(lt::error_code& ec, lt::add_torrent_params model)
 		{
 			void const* buffer = sqlite3_column_blob(stmt, 0);
 			lt::error_code ec;
-			p = lt::read_resume_data({static_cast<char const*>(buffer), bytes}, ec);
+			lt::add_torrent_params p = lt::read_resume_data({static_cast<char const*>(buffer), bytes}, ec);
 			if (ec) continue;
-			m_ses.async_add_torrent(p);
+			m_ses.async_add_torrent(std::move(p));
 		}
 
 		ret = sqlite3_step(stmt);
 	}
 	if (ret != SQLITE_DONE)
 	{
+		// TODO: improve error reporting
 		printf("failed to step select statement: %s\n", sqlite3_errmsg(m_db));
 		sqlite3_finalize(stmt);
 		return;

--- a/src/save_resume.hpp
+++ b/src/save_resume.hpp
@@ -52,7 +52,7 @@ namespace ltweb
 		save_resume(lt::session& s, std::string const& resume_file, alert_handler* alerts);
 		~save_resume();
 
-		void load(lt::error_code& ec, lt::add_torrent_params model);
+		void load(lt::error_code& ec);
 
 		// implements alert_observer
 		virtual void handle_alert(lt::alert const* a);

--- a/src/save_settings.cpp
+++ b/src/save_settings.cpp
@@ -93,6 +93,15 @@ save_settings::~save_settings() {}
 
 void save_settings::save(lt::error_code& ec) const
 {
+	// snapshot the maps before doing any I/O
+	std::map<std::string, int> ints;
+	std::map<std::string, std::string> strings;
+	{
+		std::lock_guard<std::mutex> l(m_mutex);
+		ints = m_ints;
+		strings = m_strings;
+	}
+
 	// back-up current settings file as .bak before saving the new one
 	std::string backup = m_settings_file + ".bak";
 	std::error_code fec;
@@ -110,15 +119,12 @@ void save_settings::save(lt::error_code& ec) const
 	lt::entry sett;
 	m_ses.save_state(sett);
 
-	for (auto const& i : m_ints)
-	{
+	for (auto const& i : ints)
 		sett[i.first] = i.second;
-	}
 
-	for (auto const& i : m_strings)
-	{
+	for (auto const& i : strings)
 		sett[i.first] = i.second;
-	}
+
 	std::vector<char> buf;
 	lt::bencode(std::back_inserter(buf), sett);
 	save_file(m_settings_file, buf);
@@ -184,23 +190,27 @@ void load_settings(lt::session_params& params
 
 void save_settings::set_int(char const* key, int val)
 {
+	std::lock_guard<std::mutex> l(m_mutex);
 	m_ints[key] = val;
 }
 
 void save_settings::set_str(char const* key, std::string val)
 {
-	m_strings[key] = val;
+	std::lock_guard<std::mutex> l(m_mutex);
+	m_strings[key] = std::move(val);
 }
 
 int save_settings::get_int(char const* key, int def) const
 {
-	std::map<std::string, int>::const_iterator i = m_ints.find(key);
+	std::lock_guard<std::mutex> l(m_mutex);
+	auto const i = m_ints.find(key);
 	if (i == m_ints.end()) return def;
 	return i->second;
 }
 
 std::string save_settings::get_str(char const* key, char const* def) const
 {
+	std::lock_guard<std::mutex> l(m_mutex);
 	auto const i = m_strings.find(key);
 	if (i == m_strings.end()) return def;
 	return i->second;

--- a/src/save_settings.hpp
+++ b/src/save_settings.hpp
@@ -69,6 +69,7 @@ namespace ltweb
 
 		lt::session& m_ses;
 		std::string m_settings_file;
+		mutable std::mutex m_mutex;
 		std::map<std::string, int> m_ints;
 		std::map<std::string, std::string> m_strings;
 	};

--- a/src/utorrent_webui.cpp
+++ b/src/utorrent_webui.cpp
@@ -88,15 +88,10 @@ utorrent_webui::utorrent_webui(lt::session& s, save_settings_interface* sett
 	auto hash = lt::hasher(reinterpret_cast<char const*>(&seed), sizeof(seed)).final();
 	m_token = to_hex(hash);
 
-	m_params_model.save_path = ".";
 	m_webui_cookie = "{}";
 
 	if (m_settings)
 	{
-		m_params_model.save_path = m_settings->get_str("save_path", ".");
-		m_params_model.flags
-			= (m_settings->get_int("start_paused", 0) ? lt::torrent_flags::paused : lt::torrent_flags::auto_managed)
-			| lt::torrent_flags::update_subscribe;
 		m_webui_cookie = m_settings->get_str("ut_webui_cookie", "{}");
 		int port = m_settings->get_int("listen_port", -1);
 		if (port != -1)
@@ -108,7 +103,6 @@ utorrent_webui::utorrent_webui(lt::session& s, save_settings_interface* sett
 		}
 	}
 
-	if (m_al) m_al->set_params_model(m_params_model);
 }
 
 utorrent_webui::~utorrent_webui() {}
@@ -267,7 +261,12 @@ void utorrent_webui::handle_http(http::request<http::string_body> request
 				send_http(socket, done, std::move(res));
 				return;
 			}
-			lt::add_torrent_params p = m_params_model;
+			lt::add_torrent_params p;
+			p.save_path = m_settings ? m_settings->get_str("save_path", "./downloads") : "./downloads";
+			if (m_settings && m_settings->get_int("start_paused", 0))
+				p.flags = (p.flags & ~lt::torrent_flags::auto_managed) | lt::torrent_flags::paused;
+			else
+				p.flags = (p.flags & ~lt::torrent_flags::paused) | lt::torrent_flags::auto_managed;
 			lt::error_code ec;
 			if (!parse_torrent_post(request, p, ec))
 			{
@@ -444,9 +443,10 @@ void utorrent_webui::remove_torrent_and_data(std::vector<char>&, char const* arg
 
 void utorrent_webui::list_dirs(std::vector<char>& response, char const* args, permissions_interface const* p)
 {
+	std::string const save_path = m_settings ? m_settings->get_str("save_path", "./downloads") : "./downloads";
 	appendf(response, ", \"download-dirs\": [{\"path\":\"%s\",\"available\":%" PRId64 "}]"
-		, escape_json(m_params_model.save_path).c_str()
-		, free_disk_space(m_params_model.save_path) / 1024 / 1024);
+		, escape_json(save_path).c_str()
+		, free_disk_space(save_path) / 1024 / 1024);
 }
 
 char const* settings_name(int s)
@@ -568,7 +568,7 @@ void utorrent_webui::get_settings(std::vector<char>& response, char const* args
 	}
 
 	appendf(response, ",[\"torrents_start_stopped\",1,\"%s\",{\"access\":\"%c\"}]\n" + first
-		, m_params_model.flags & lt::torrent_flags::paused ? "true" : "false"
+		, (m_settings && m_settings->get_int("start_paused", 0)) ? "true" : "false"
 		, p->allow_stop() ? 'Y' : 'R');
 	first = 0;
 
@@ -609,7 +609,7 @@ void utorrent_webui::get_settings(std::vector<char>& response, char const* args
 			",[\"dir_active_download\",2,\"%s\",{\"access\":\"%c\"}]\n"
 			",[\"bind_port\",0,\"%d\",{\"access\":\"%c\"}]\n"
 			+ first
-			, escape_json(m_params_model.save_path).c_str()
+			, escape_json(m_settings ? m_settings->get_str("save_path", "./downloads") : "./downloads").c_str()
 			, p->allow_set_settings(-1) ? 'Y' : 'R'
 			, m_ses.listen_port()
 			, p->allow_set_settings(-1) ? 'Y' : 'R');
@@ -725,22 +725,7 @@ void utorrent_webui::set_settings(std::vector<char>& response, char const* args,
 		else if (key == "torrents_start_stopped")
 		{
 			if (!p->allow_stop()) continue;
-			bool b = to_bool(value);
-			if (b)
-			{
-				m_params_model.flags = (m_params_model.flags
-					& ~lt::torrent_flags::auto_managed)
-					| lt::torrent_flags::paused;
-			}
-			else
-			{
-				m_params_model.flags = (m_params_model.flags
-					| lt::torrent_flags::auto_managed)
-					& ~lt::torrent_flags::paused;
-			}
-			if (m_al)
-				m_al->set_params_model(m_params_model);
-			m_settings->set_int("start_paused", b);
+			if (m_settings) m_settings->set_int("start_paused", to_bool(value));
 		}
 		else if (key == "dir_autoload" && m_al)
 		{
@@ -755,9 +740,6 @@ void utorrent_webui::set_settings(std::vector<char>& response, char const* args,
 		else if (key == "dir_active_download")
 		{
 			if (!p->allow_set_settings(-1)) continue;
-			m_params_model.save_path = value;
-			if (m_al)
-				m_al->set_params_model(m_params_model);
 			if (m_settings) m_settings->set_str("save_path", value);
 		}
 /*
@@ -914,9 +896,13 @@ void utorrent_webui::add_url(std::vector<char>&, char const* args, permissions_i
 	std::string const url_str = url_decode(*url_val);
 
 	lt::add_torrent_params atp = lt::parse_magnet_uri(url_str);
-	atp.save_path = m_params_model.save_path;
+	atp.save_path = m_settings ? m_settings->get_str("save_path", "./downloads") : "./downloads";
+	if (m_settings && m_settings->get_int("start_paused", 0))
+		atp.flags = (atp.flags & ~lt::torrent_flags::auto_managed) | lt::torrent_flags::paused;
+	else
+		atp.flags = (atp.flags & ~lt::torrent_flags::paused) | lt::torrent_flags::auto_managed;
 
-	m_ses.async_add_torrent(atp);
+	m_ses.async_add_torrent(std::move(atp));
 }
 
 void utorrent_webui::get_properties(std::vector<char>& response, char const* args, permissions_interface const* p)

--- a/src/utorrent_webui.hpp
+++ b/src/utorrent_webui.hpp
@@ -35,7 +35,6 @@ POSSIBILITY OF SUCH DAMAGE.
 
 #include "webui.hpp"
 #include "libtorrent/torrent_handle.hpp"
-#include "libtorrent/add_torrent_params.hpp"
 #include <cstdint>
 #include <functional>
 #include <vector>
@@ -56,9 +55,6 @@ namespace ltweb
 			, auto_load* al = NULL, torrent_history* hist = NULL
 			, auth_interface const* auth = NULL);
 		~utorrent_webui();
-
-		void set_params_model(lt::add_torrent_params const& p)
-		{ m_params_model = p; }
 
 		virtual std::string path_prefix() const override { return "/gui"; }
 		virtual void handle_http(http::request<http::string_body> request
@@ -106,7 +102,6 @@ namespace ltweb
 
 		time_t m_start_time;
 		lt::session& m_ses;
-		lt::add_torrent_params m_params_model;
 		std::string m_webui_cookie;
 
 		// optional auto loader, controllable

--- a/test.cpp
+++ b/test.cpp
@@ -63,9 +63,8 @@ int main(int argc, char *const argv[])
 //	pam_auth authorizer("bittorrent");
 
 	save_resume resume(ses, "resume.dat", &alerts);
-	add_torrent_params p;
-	p.save_path = sett.get_str("save_path", ".");
-	resume.load(ec, p);
+	resume.load(ec);
+	// TODO: log error if ec is set
 
 	stats_logging log(ses, &alerts);
 
@@ -77,7 +76,7 @@ int main(int argc, char *const argv[])
 
 	// websocket access to controlling the bittorrent client exposed at HTTP
 	// path /bt/control
-	libtorrent_webui lt_handler(ses, &hist, &authorizer, &alerts);
+	libtorrent_webui lt_handler(ses, &hist, &authorizer, &alerts, &sett);
 	webport.add_handler(&lt_handler);
 
 	// allows requesting files from within torrents exposed at HTTP path


### PR DESCRIPTION
just read save path and flags from settings. This is to prepare for the new way of loading torrents directly into add_torrent_params