### PR TITLE
fix torrent_history to only use truncated info-hashes

### DIFF
--- a/src/libtorrent_webui.cpp
+++ b/src/libtorrent_webui.cpp
@@ -313,7 +313,7 @@ namespace {
 		std::vector<torrent_history_entry> torrents;
 		m_hist->updated_fields_since(frame, torrents);
 
-		std::vector<lt::info_hash_t> const removed_torrents = m_hist->removed_since(frame);
+		std::vector<lt::sha1_hash> const removed_torrents = m_hist->removed_since(frame);
 
 		std::vector<char> response;
 		std::back_insert_iterator<std::vector<char> > ptr(response);
@@ -507,11 +507,8 @@ namespace {
 		write_uint32(num_torrents, ptr2);
 
 		// send list of removed torrents
-		for (auto const& i : removed_torrents)
-		{
-			auto const ih = i.get_best();
+		for (auto const& ih : removed_torrents)
 			std::copy(ih.begin(), ih.end(), ptr);
-		}
 
 		return st->send_packet(response.data(), response.size());
 	}

--- a/src/torrent_history.cpp
+++ b/src/torrent_history.cpp
@@ -63,7 +63,7 @@ namespace ltweb
 				m_queue.right.erase(it);
 			}
 
-			m_removed.push_front({m_frame + 1, added_frame, td->info_hashes});
+			m_removed.push_front({m_frame + 1, added_frame, td->info_hashes.get_best()});
 
 			// weed out torrents that were removed a long time ago
 			if (m_removed.size() > 1000)
@@ -110,9 +110,9 @@ namespace ltweb
 	}
 	catch (std::exception const&) {}
 
-    std::vector<lt::info_hash_t> torrent_history::removed_since(frame_t frame) const
+	std::vector<lt::sha1_hash> torrent_history::removed_since(frame_t frame) const
 	{
-        std::vector<lt::info_hash_t> torrents;
+		std::vector<lt::sha1_hash> torrents;
 		std::unique_lock<std::mutex> l(m_mutex);
 		for (auto const& e : m_removed)
 		{
@@ -154,25 +154,6 @@ namespace ltweb
 		std::unique_lock<std::mutex> l(m_mutex);
 
 		queue_t::right_const_iterator it = m_queue.right.find(st);
-		if (it != m_queue.right.end()) return it->first.status;
-		return st.status;
-	}
-
-	lt::torrent_status torrent_history::get_torrent_status(lt::sha256_hash const& ih) const
-	{
-		torrent_history_entry st;
-		st.status.info_hashes.v2 = ih;
-
-		std::unique_lock<std::mutex> l(m_mutex);
-
-		queue_t::right_const_iterator it = m_queue.right.find(st);
-		if (it != m_queue.right.end()) return it->first.status;
-
-        // if we can't find it by the v2 hash, try a truncated v2 hash
-		// (a torrent added via v2-only magnet link may be stored with only the
-		// first 20 bytes of the sha256 in v1, and v2 left empty)
-		st.status.info_hashes = lt::info_hash_t(lt::sha1_hash(ih.data()));
-		it = m_queue.right.find(st);
 		if (it != m_queue.right.end()) return it->first.status;
 		return st.status;
 	}

--- a/src/torrent_history.hpp
+++ b/src/torrent_history.hpp
@@ -45,7 +45,7 @@ namespace ltweb
 
 		void update_status(lt::torrent_status const& s, frame_t frame);
 
-		bool operator==(torrent_history_entry const& e) const { return e.status.info_hashes == status.info_hashes; }
+		bool operator==(torrent_history_entry const& e) const { return e.status.info_hashes.get_best() == status.info_hashes.get_best(); }
 
 		enum
 		{
@@ -135,7 +135,7 @@ namespace ltweb
 	};
 
 	inline std::size_t hash_value(torrent_history_entry const& te)
-	{ return std::hash<lt::info_hash_t>{}(te.status.info_hashes); }
+	{ return std::hash<lt::sha1_hash>{}(te.status.info_hashes.get_best()); }
 
 	struct torrent_history : alert_observer
 	{
@@ -145,7 +145,7 @@ namespace ltweb
 
 		// returns the info-hashes of the torrents that have been
 		// removed since the specified frame number
-		std::vector<lt::info_hash_t> removed_since(frame_t frame) const;
+		std::vector<lt::sha1_hash> removed_since(frame_t frame) const;
 
 		// returns the lt::torrent_status structures for the torrents
 		// that have changed since the specified frame number
@@ -154,7 +154,6 @@ namespace ltweb
 		void updated_fields_since(frame_t frame, std::vector<torrent_history_entry>& torrents) const;
 
 		lt::torrent_status get_torrent_status(lt::sha1_hash const& ih) const;
-		lt::torrent_status get_torrent_status(lt::sha256_hash const& ih) const;
 
 		// the current frame number
 		frame_t frame() const;
@@ -177,7 +176,7 @@ namespace ltweb
 		{
 			frame_t removed_frame;
 			frame_t added_frame;
-			lt::info_hash_t ih;
+			lt::sha1_hash ih;
 		};
 		std::deque<removed_entry> m_removed;
 

--- a/src/utorrent_webui.cpp
+++ b/src/utorrent_webui.cpp
@@ -1229,7 +1229,7 @@ void utorrent_webui::send_torrent_list(std::vector<char>& response, char const* 
 		appendf(response, "\"%s\"", to_hex(i).c_str());
 	}
 	// TODO: support labels
-	appendf(response, "], \"label\": [], \"torrentc\": \"%d\"", m_hist->frame());
+	appendf(response, "], \"label\": [], \"torrentc\": \"%" PRIu32 "\"", m_hist->frame());
 }
 
 void utorrent_webui::send_rss_list(std::vector<char>& response, char const* args, permissions_interface const* p)

--- a/src/utorrent_webui.cpp
+++ b/src/utorrent_webui.cpp
@@ -1218,15 +1218,15 @@ void utorrent_webui::send_torrent_list(std::vector<char>& response, char const* 
 		}
 	}
 
-	std::vector<lt::info_hash_t> const removed = m_hist->removed_since(cid);
+	std::vector<lt::sha1_hash> const removed = m_hist->removed_since(cid);
 
 	appendf(response, "], \"torrentm\": [");
 	first = true;
-	for (lt::info_hash_t const& i : removed)
+	for (lt::sha1_hash const& i : removed)
 	{
 		if (!first) response.push_back(',');
 		first = false;
-		appendf(response, "\"%s\"", to_hex(i.get_best()).c_str());
+		appendf(response, "\"%s\"", to_hex(i).c_str());
 	}
 	// TODO: support labels
 	appendf(response, "], \"label\": [], \"torrentc\": \"%d\"", m_hist->frame());

--- a/tests/test_torrent_history.cpp
+++ b/tests/test_torrent_history.cpp
@@ -81,18 +81,14 @@ BOOST_AUTO_TEST_CASE(integration)
 	ltweb::alert_handler handler(ses);
 	ltweb::torrent_history history(&handler);
 
-	// Four distinct hash identities covering all torrent types:
+	// Three distinct hash identities covering all torrent types:
 	//   v1_hash  -- v1-only (sha1 only)
 	//   v2_hash  -- v2-only (sha256 only, v1 left zero)
 	//   hy_v1/hy_v2 -- hybrid (both sha1 and sha256 set)
-	//   tr_v2    -- v2 hash whose first 20 bytes will be stored as a v1 "truncated" hash
 	lt::sha1_hash const v1_hash = make_v1(0x11);
 	lt::sha256_hash const v2_hash = make_v2(0x22);
 	lt::sha1_hash const hy_v1 = make_v1(0x33);
 	lt::sha256_hash const hy_v2 = make_v2(0x44);
-	lt::sha256_hash const tr_v2 = make_v2(0x55);
-	// The truncated form stores only the first 20 bytes of tr_v2 as a sha1
-	lt::sha1_hash const tr_as_v1(tr_v2.data());
 
 	lt::add_torrent_params p;
 	p.save_path = ".";
@@ -111,37 +107,19 @@ BOOST_AUTO_TEST_CASE(integration)
 	lt::torrent_handle h3 = ses.add_torrent(p);
 	(void)h3;
 
-	// Add a torrent whose "v1" hash is really the first 20 bytes of a v2 hash.
-	p.info_hashes = lt::info_hash_t(tr_as_v1);
-	lt::torrent_handle h4 = ses.add_torrent(p);
-	(void)h4;
+	wait_for(ses, handler, 3, lt::add_torrent_alert::alert_type);
 
-	wait_for(ses, handler, 4, lt::add_torrent_alert::alert_type);
-
-	// All four torrents must appear in the history
+	// All three torrents must appear in the history
 	{
 		std::vector<lt::torrent_status> all;
 		history.updated_since(0, all);
-		BOOST_TEST(all.size() == 4);
+		BOOST_TEST(all.size() == 3);
 	}
 
 	// v1-only lookup by sha1 hash
 	{
 		auto const st = history.get_torrent_status(v1_hash);
 		BOOST_TEST((st.info_hashes == lt::info_hash_t(v1_hash)));
-	}
-
-	// v2-only lookup by full sha256 hash (direct match path)
-	{
-		auto const st = history.get_torrent_status(v2_hash);
-		BOOST_TEST((st.info_hashes == lt::info_hash_t(v2_hash)));
-	}
-
-	// Truncated-v2 lookup: given a full sha256 hash, find a torrent that
-	// was stored with only its first 20 bytes as a sha1 (v2 is zero).
-	{
-		auto const st = history.get_torrent_status(tr_v2);
-		BOOST_TEST((st.info_hashes == lt::info_hash_t(tr_as_v1)));
 	}
 
 	// Hybrid torrent appears in updated_since
@@ -187,14 +165,14 @@ BOOST_AUTO_TEST_CASE(integration)
 		auto const removed = history.removed_since(f);
 		BOOST_TEST(removed.size() == 1);
 		if (!removed.empty())
-			BOOST_TEST((removed[0] == lt::info_hash_t(v1_hash)));
+			BOOST_TEST((removed[0] == v1_hash));
 	}
 
 	// After removal the torrent no longer shows up in updated_since
 	{
 		std::vector<lt::torrent_status> remaining;
 		history.updated_since(0, remaining);
-		BOOST_TEST(remaining.size() == 3);
+		BOOST_TEST(remaining.size() == 2);
 		for (auto const& s : remaining)
 			BOOST_TEST((s.info_hashes != lt::info_hash_t(v1_hash)));
 	}
@@ -240,6 +218,6 @@ BOOST_AUTO_TEST_CASE(removed_before_client_saw_add)
 		auto const removed = history.removed_since(f1);
 		BOOST_TEST(removed.size() == 1);
 		if (!removed.empty())
-			BOOST_TEST((removed[0] == lt::info_hash_t(make_v1(0xbb))));
+			BOOST_TEST((removed[0] == make_v1(0xbb)));
 	}
 }


### PR DESCRIPTION
Fixes issue with hybrid torrents; should be broken out