### PR TITLE
improve torrent_history and piece_history

### DIFF
--- a/bt/libtorrent-webui.js
+++ b/bt/libtorrent-webui.js
@@ -487,11 +487,16 @@ libtorrent_connection.prototype['get_updates'] = function(mask, callback)
 			ret[infohash] = torrent;
 		}
 
+		ret['snapshot'] = num_removed_torrents == 0xffffffff;
+
 		var removed = [];
-		for (var i = 0; i < num_removed_torrents; ++i)
+		if (num_removed_torrents != 0xffffffff)
 		{
-			removed.push(read_infohash(view, offset));
-			offset += 20;
+			for (var i = 0; i < num_removed_torrents; ++i)
+			{
+				removed.push(read_infohash(view, offset));
+				offset += 20;
+			}
 		}
 		ret['removed'] = removed;
 

--- a/src/libtorrent_webui.cpp
+++ b/src/libtorrent_webui.cpp
@@ -332,10 +332,9 @@ namespace {
 		std::uint64_t user_mask = read_uint64(f.data);
 		f.len -= 12;
 
-		std::vector<torrent_history_entry> torrents;
-		m_hist.updated_fields_since(frame, torrents);
-
-		std::vector<lt::sha1_hash> const removed_torrents = m_hist.removed_since(frame);
+		auto const r = m_hist.query(frame);
+		auto const& torrents = r.updated;
+		auto const& removed_torrents = r.removed;
 
 		std::vector<char> response;
 		std::back_insert_iterator<std::vector<char> > ptr(response);
@@ -353,9 +352,9 @@ namespace {
 		int const num_torrents_pos = response.size();
 		write_uint32(num_torrents, ptr);
 
-		write_uint32(removed_torrents.size(), ptr);
+		write_uint32(r.is_snapshot ? 0xffffffff : removed_torrents.size(), ptr);
 
-		for (std::vector<torrent_history_entry>::iterator i = torrents.begin()
+		for (std::vector<torrent_history_entry>::const_iterator i = torrents.begin()
 			, end(torrents.end()); i != end; ++i)
 		{
 			std::uint64_t bitmask = 0;
@@ -366,7 +365,7 @@ namespace {
 			{
 				int f = torrent_field_map[k];
 				if (f < 0) continue;
-				if (i->frame[k] <= frame) continue;
+				if (i->frame[k] <= frame && !r.is_snapshot) continue;
 
 				// this field has changed and should be included in this update
 				bitmask |= 1 << f;
@@ -1367,15 +1366,12 @@ namespace {
 		}
 		frame_t const new_frame = m_piece_histories.front().update(pieces);
 
-		auto const [full_pieces, block_updates, removed] =
-			m_piece_histories.front().query(client_frame);
-
-		bool const snapshot = (client_frame == 0);
+		auto const r = m_piece_histories.front().query(client_frame);
 
 		// cap all counts to 16-bit
-		std::uint16_t const n_full = static_cast<std::uint16_t>(std::min(full_pieces.size(), std::size_t(0xffffu)));
-		std::uint16_t const n_updates = static_cast<std::uint16_t>(std::min(block_updates.size(), std::size_t(0xffffu)));
-		std::uint16_t const n_removed = static_cast<std::uint16_t>(std::min(removed.size(), std::size_t(0xffffu)));
+		std::uint16_t const n_full = static_cast<std::uint16_t>(std::min(r.full_pieces.size(), std::size_t(0xffffu)));
+		std::uint16_t const n_updates = static_cast<std::uint16_t>(std::min(r.block_updates.size(), std::size_t(0xffffu)));
+		std::uint16_t const n_removed = static_cast<std::uint16_t>(std::min(r.removed.size(), std::size_t(0xffffu)));
 
 		std::back_insert_iterator<std::vector<char>> ptr(response);
 
@@ -1385,26 +1381,26 @@ namespace {
 		write_uint32(new_frame, ptr);
 		write_uint16(n_full, ptr);
 		write_uint16(n_updates, ptr);
-		write_uint16(snapshot ? std::uint16_t(0xffffu) : n_removed, ptr);
+		write_uint16(r.is_snapshot ? std::uint16_t(0xffffu) : n_removed, ptr);
 
 		for (std::uint16_t i = 0; i < n_full; ++i)
 		{
-			auto const* e = full_pieces[i];
+			auto const* e = r.full_pieces[i];
 			write_uint32(static_cast<int>(e->piece_index), ptr);
 			write_uint16(static_cast<std::uint16_t>(e->blocks.size()), ptr);
 			for (auto const& b : e->blocks) write_uint8(b.state, ptr);
 		}
 		for (std::uint16_t i = 0; i < n_updates; ++i)
 		{
-			auto const& bu = block_updates[i];
+			auto const& bu = r.block_updates[i];
 			write_uint32(static_cast<int>(bu.piece_index), ptr);
 			write_uint16(static_cast<std::uint16_t>(bu.block_index), ptr);
 			write_uint8(bu.state, ptr);
 		}
-		if (!snapshot)
+		if (!r.is_snapshot)
 		{
 			for (std::uint16_t i = 0; i < n_removed; ++i)
-				write_uint32(static_cast<int>(removed[i]), ptr);
+				write_uint32(static_cast<int>(r.removed[i]), ptr);
 		}
 		l.unlock();
 

--- a/src/piece_history.cpp
+++ b/src/piece_history.cpp
@@ -13,8 +13,9 @@ see LICENSE file.
 
 namespace ltweb {
 
-piece_history::piece_history(lt::sha1_hash const& ih)
+piece_history::piece_history(lt::sha1_hash const& ih, std::size_t max_tombstones)
 	: m_ih(ih)
+	, m_max_tombstones(max_tombstones)
 {}
 
 frame_t piece_history::update(
@@ -72,12 +73,11 @@ frame_t piece_history::update(
 		}
 	}
 
-	// Prune old removal entries to keep the deque bounded.
-	if (m_removed.size() > 1000)
+	// Evict oldest tombstones when over the limit (deque is newest-first).
+	while (m_removed.size() > m_max_tombstones)
 	{
-		auto const it = std::remove_if(m_removed.begin(), m_removed.end(),
-			[&](auto const& r) { return frame - r.removed_frame > 60; });
-		m_removed.erase(it, m_removed.end());
+		m_horizon = std::max(m_horizon, m_removed.back().removed_frame + 1);
+		m_removed.pop_back();
 	}
 
 	return frame;
@@ -87,9 +87,11 @@ piece_history::query_result piece_history::query(frame_t since_frame) const
 {
 	query_result result;
 
-	if (since_frame == 0)
+	if (since_frame < m_horizon) since_frame = 0;
+	result.is_snapshot = (since_frame == 0);
+
+	if (result.is_snapshot)
 	{
-		// Full snapshot: every current piece as a full update.
 		for (auto const& [idx, entry] : m_pieces)
 			result.full_pieces.push_back(&entry);
 		return result;
@@ -109,7 +111,6 @@ piece_history::query_result piece_history::query(frame_t since_frame) const
 	{
 		if (entry.added_frame > since_frame)
 		{
-			// New piece: client doesn't know about it; must send all blocks.
 			result.full_pieces.push_back(&entry);
 			continue;
 		}
@@ -121,8 +122,6 @@ piece_history::query_result piece_history::query(frame_t since_frame) const
 
 		if (changed == 0) continue;
 
-		// Full update costs (num_blocks + 6) bytes.
-		// Individual block updates cost (changed * 7) bytes.
 		if (num_blocks + 6 <= changed * 7)
 		{
 			result.full_pieces.push_back(&entry);

--- a/src/piece_history.hpp
+++ b/src/piece_history.hpp
@@ -40,10 +40,14 @@ struct piece_history_entry
 // instance for a different torrent.
 struct piece_history
 {
-	explicit piece_history(lt::sha1_hash const& ih);
+	explicit piece_history(lt::sha1_hash const& ih, std::size_t max_tombstones = 1000);
 
 	lt::sha1_hash const& info_hash() const { return m_ih; }
 	frame_t frame() const { return m_frame; }
+
+	// The oldest frame for which delta queries are reliable.
+	// Any query with since_frame < horizon() is treated as a full snapshot.
+	frame_t horizon() const { return m_horizon; }
 
 	// Feed a fresh download queue snapshot.
 	// Increments the internal frame counter and returns the new frame.
@@ -58,6 +62,9 @@ struct piece_history
 
 	struct query_result
 	{
+		// true when since_frame was 0 or was clamped to 0 due to horizon eviction.
+		bool is_snapshot = false;
+
 		// Pieces whose full block array should be sent.
 		// Includes: pieces new since since_frame, and pieces where sending all
 		// blocks is cheaper than individual block updates.
@@ -69,7 +76,7 @@ struct piece_history
 		// Piece indices removed since since_frame.
 		// Only includes pieces whose added_frame <= since_frame (i.e. the client
 		// had already seen the piece before it was removed).
-		// Empty when since_frame == 0 (snapshot mode; caller sends 0xffff).
+		// Empty when is_snapshot is true (caller sends num_removed=0xffff).
 		std::vector<lt::piece_index_t> removed;
 	};
 
@@ -88,6 +95,8 @@ struct piece_history
 private:
 	lt::sha1_hash const m_ih;
 	frame_t m_frame = 0;
+	frame_t m_horizon = 0;
+	std::size_t m_max_tombstones;
 
 	// ordered by piece_index for deterministic iteration
 	std::map<lt::piece_index_t, piece_history_entry> m_pieces;

--- a/src/torrent_history.cpp
+++ b/src/torrent_history.cpp
@@ -17,10 +17,11 @@ see LICENSE file.
 
 namespace ltweb
 {
-	torrent_history::torrent_history(alert_handler* h)
+	torrent_history::torrent_history(alert_handler* h, std::size_t max_tombstones)
 		: m_alerts(h)
 		, m_frame(1)
 		, m_deferred_frame_count(false)
+		, m_max_tombstones(max_tombstones)
 	{
 		m_alerts->subscribe(this, 0
 			, lt::add_torrent_alert::alert_type
@@ -66,15 +67,12 @@ namespace ltweb
 
 			m_removed.push_front({m_frame + 1, added_frame, td->info_hashes.get_best()});
 
-			// weed out torrents that were removed a long time ago
-			if (m_removed.size() > 1000)
+			// Evict oldest tombstones when over the limit. The deque is
+			// newest-first, so back() is always the oldest entry.
+			while (m_removed.size() > m_max_tombstones)
 			{
-				auto const pruned = std::remove_if(
-					m_removed.begin()
-					, m_removed.end()
-					, [&](auto const& e) { return e.removed_frame < m_frame - 60; }
-				);
-				m_removed.erase(pruned, m_removed.end());
+				m_horizon = std::max(m_horizon, m_removed.back().removed_frame + 1);
+				m_removed.pop_back();
 			}
 
 			m_deferred_frame_count = true;
@@ -111,40 +109,36 @@ namespace ltweb
 	}
 	catch (std::exception const&) {}
 
-	std::vector<lt::sha1_hash> torrent_history::removed_since(frame_t frame) const
+	torrent_history::query_result torrent_history::query(frame_t since_frame) const
 	{
-		std::vector<lt::sha1_hash> torrents;
+		query_result result;
 		std::unique_lock<std::mutex> l(m_mutex);
-		for (auto const& e : m_removed)
-		{
-			if (e.removed_frame <= frame) break;
-			// Only notify clients that could have seen the add. If the torrent
-			// was added after the client's last frame it was never visible to
-			// that client, so there is nothing to remove on their side.
-			if (e.added_frame <= frame)
-				torrents.push_back(e.ih);
-		}
-		return torrents;
-	}
+		if (since_frame < m_horizon) since_frame = 0;
+		result.is_snapshot = (since_frame == 0);
 
-	void torrent_history::updated_since(frame_t frame, std::vector<lt::torrent_status>& torrents) const
-	{
-		std::unique_lock<std::mutex> l(m_mutex);
 		for (auto const& e : m_queue.left)
 		{
-			if (e.first <= frame) break;
-			torrents.push_back(e.second.status);
+			if (e.first <= since_frame) break;
+			result.updated.push_back(e.second);
 		}
+
+		if (!result.is_snapshot)
+		{
+			for (auto const& e : m_removed)
+			{
+				if (e.removed_frame <= since_frame) break;
+				if (e.added_frame <= since_frame)
+					result.removed.push_back(e.ih);
+			}
+		}
+
+		return result;
 	}
 
-	void torrent_history::updated_fields_since(frame_t frame, std::vector<torrent_history_entry>& torrents) const
+	frame_t torrent_history::horizon() const
 	{
 		std::unique_lock<std::mutex> l(m_mutex);
-		for (auto const& e : m_queue.left)
-		{
-			if (e.first <= frame) break;
-			torrents.push_back(e.second);
-		}
+		return m_horizon;
 	}
 
 	lt::torrent_status torrent_history::get_torrent_status(lt::sha1_hash const& ih) const

--- a/src/torrent_history.hpp
+++ b/src/torrent_history.hpp
@@ -140,23 +140,32 @@ namespace ltweb
 	struct torrent_history : alert_observer
 	{
 
-		torrent_history(alert_handler* h);
+		torrent_history(alert_handler* h, std::size_t max_tombstones = 1000);
 		~torrent_history();
 
-		// returns the info-hashes of the torrents that have been
-		// removed since the specified frame number
-		std::vector<lt::sha1_hash> removed_since(frame_t frame) const;
+		struct query_result
+		{
+			bool is_snapshot = false;
+			std::vector<torrent_history_entry> updated;
+			std::vector<lt::sha1_hash> removed;
+		};
 
-		// returns the lt::torrent_status structures for the torrents
-		// that have changed since the specified frame number
-		void updated_since(frame_t frame, std::vector<lt::torrent_status>& torrents) const;
-
-		void updated_fields_since(frame_t frame, std::vector<torrent_history_entry>& torrents) const;
+		// Returns all torrents updated since since_frame and all info-hashes
+		// removed since since_frame, in a single locked operation.
+		// If since_frame < horizon(), the result is promoted to a full snapshot:
+		// is_snapshot is true, updated contains all live torrents, removed is empty.
+		query_result query(frame_t since_frame) const;
 
 		lt::torrent_status get_torrent_status(lt::sha1_hash const& ih) const;
 
 		// the current frame number
 		frame_t frame() const;
+
+		// the oldest frame for which delta queries are reliable.
+		// Any query with since_frame < horizon() will be treated as a full
+		// snapshot (since_frame == 0), because tombstones older than this
+		// frame have been evicted.
+		frame_t horizon() const;
 
 		virtual void handle_alert(lt::alert const* a);
 
@@ -195,6 +204,13 @@ namespace ltweb
 		// happen and once after we've received an
 		// update and increment the frame counter
 		mutable bool m_deferred_frame_count;
+
+		// The oldest frame for which we still have complete tombstone data.
+		// Advanced whenever tombstones are evicted from m_removed.
+		frame_t m_horizon = 0;
+
+		// Maximum number of tombstones to keep. Configurable for testing.
+		std::size_t m_max_tombstones;
 	};
 }
 

--- a/src/utorrent_webui.cpp
+++ b/src/utorrent_webui.cpp
@@ -1153,14 +1153,14 @@ void utorrent_webui::send_torrent_list(std::vector<char>& response, char const* 
 	if (auto const cid_val = get_query_var(args, "cid"))
 		cid = atoi(url_decode(*cid_val).c_str());
 
-	appendf(response, cid > 0 ? ",\"torrentp\":[" : ",\"torrents\":[");
+	auto const r = m_hist.query(cid);
 
-	std::vector<lt::torrent_status> torrents;
-	m_hist.updated_since(cid, torrents);
+	appendf(response, !r.is_snapshot ? ",\"torrentp\":[" : ",\"torrents\":[");
 
 	bool first = true;
-	for (lt::torrent_status const& t : torrents)
+	for (torrent_history_entry const& e : r.updated)
 	{
+		lt::torrent_status const& t = e.status;
 		std::shared_ptr<const lt::torrent_info> ti = t.torrent_file.lock();
 		if (!first) response.push_back(',');
 		first = false;
@@ -1207,11 +1207,9 @@ void utorrent_webui::send_torrent_list(std::vector<char>& response, char const* 
 		}
 	}
 
-	std::vector<lt::sha1_hash> const removed = m_hist.removed_since(cid);
-
 	appendf(response, "], \"torrentm\": [");
 	first = true;
-	for (lt::sha1_hash const& i : removed)
+	for (lt::sha1_hash const& i : r.removed)
 	{
 		if (!first) response.push_back(',');
 		first = false;

--- a/tests/test_piece_history.cpp
+++ b/tests/test_piece_history.cpp
@@ -77,6 +77,7 @@ BOOST_AUTO_TEST_CASE(snapshot)
 	ph.update(q.pieces);
 	auto const r = ph.query(0);
 
+	BOOST_TEST(r.is_snapshot);
 	BOOST_TEST(r.full_pieces.size() == 2u);
 	BOOST_TEST(r.block_updates.empty());
 	BOOST_TEST(r.removed.empty());
@@ -94,6 +95,7 @@ BOOST_AUTO_TEST_CASE(delta_no_change)
 	ph.update(q.pieces);  // identical state
 
 	auto const r = ph.query(f1);
+	BOOST_TEST(!r.is_snapshot);
 	BOOST_TEST(r.full_pieces.empty());
 	BOOST_TEST(r.block_updates.empty());
 	BOOST_TEST(r.removed.empty());
@@ -114,6 +116,7 @@ BOOST_AUTO_TEST_CASE(delta_sends_individual_block_updates)
 	ph.update(q2.pieces);
 
 	auto const r = ph.query(f1);
+	BOOST_TEST(!r.is_snapshot);
 	BOOST_TEST(r.full_pieces.empty());
 	BOOST_TEST(r.block_updates.size() == 1u);
 	BOOST_TEST(r.removed.empty());
@@ -140,6 +143,7 @@ BOOST_AUTO_TEST_CASE(delta_sends_full_piece_when_cheaper)
 	ph.update(q2.pieces);
 
 	auto const r = ph.query(f1);
+	BOOST_TEST(!r.is_snapshot);
 	BOOST_TEST(r.full_pieces.size() == 1u);
 	BOOST_TEST(r.block_updates.empty());
 	BOOST_TEST(r.removed.empty());
@@ -160,6 +164,7 @@ BOOST_AUTO_TEST_CASE(new_piece_sent_as_full_piece)
 	ph.update(q2.pieces);
 
 	auto const r = ph.query(f1);
+	BOOST_TEST(!r.is_snapshot);
 	BOOST_TEST(r.full_pieces.size() == 1u);
 	BOOST_TEST(r.block_updates.empty());
 	BOOST_TEST(r.removed.empty());
@@ -184,6 +189,7 @@ BOOST_AUTO_TEST_CASE(removed_piece_reported_to_client)
 	// Client last polled at f1 -- it saw piece 3 -- so it must be told
 	// about the removal.
 	auto const r = ph.query(f1);
+	BOOST_TEST(!r.is_snapshot);
 	BOOST_TEST(r.removed.size() == 1u);
 	if (!r.removed.empty())
 		BOOST_TEST((r.removed[0] == lt::piece_index_t(3)));
@@ -203,14 +209,14 @@ BOOST_AUTO_TEST_CASE(removed_piece_not_reported_if_client_never_saw_add)
 	ph.update(q2.pieces);                  // piece 3 disappears
 
 	// Client at f0: added_frame > f0 -> not in removed
-	auto const r = ph.query(f0);
-	BOOST_TEST(r.removed.empty());
+	auto const r0 = ph.query(f0);
+	BOOST_TEST(r0.removed.empty());
 
 	// Client at f1: added_frame <= f1 -> should be in removed
-	auto const r2 = ph.query(f1);
-	BOOST_TEST(r2.removed.size() == 1u);
-	if (!r2.removed.empty())
-		BOOST_TEST((r2.removed[0] == lt::piece_index_t(3)));
+	auto const r1 = ph.query(f1);
+	BOOST_TEST(r1.removed.size() == 1u);
+	if (!r1.removed.empty())
+		BOOST_TEST((r1.removed[0] == lt::piece_index_t(3)));
 }
 
 // When a piece reappears after being removed, its removal entry must be
@@ -242,4 +248,63 @@ BOOST_AUTO_TEST_CASE(piece_reappears_after_removal)
 	for (auto const* e : r.full_pieces)
 		if (e->piece_index == lt::piece_index_t(2)) in_full = true;
 	BOOST_TEST(in_full);
+}
+
+// When tombstones overflow the limit the oldest are evicted and the horizon
+// advances.  A query with since_frame < horizon() must behave like a full
+// snapshot (since_frame == 0): all current pieces in full_pieces, removed empty.
+BOOST_AUTO_TEST_CASE(horizon_after_tombstone_eviction)
+{
+	// Limit to 2 tombstones so the third removal triggers eviction.
+	ltweb::piece_history ph(make_hash(0x11), 2);
+
+	BOOST_TEST(ph.horizon() == 0u);
+
+	// Frame 1: add pieces 0, 1, 2.
+	fake_queue q_add;
+	q_add.add(0, {1, 1});
+	q_add.add(1, {1, 1});
+	q_add.add(2, {1, 1});
+	auto const f_client = ph.update(q_add.pieces);
+
+	// Frame 2: remove all three pieces (empty queue).
+	// The third tombstone overflows the limit; one is evicted and horizon advances.
+	fake_queue q_empty;
+	ph.update(q_empty.pieces);
+
+	BOOST_TEST(ph.horizon() > 0u);
+
+	// Frame 3: add a new piece so there is something to snapshot.
+	fake_queue q_new;
+	q_new.add(5, {0, 1});
+	ph.update(q_new.pieces);
+
+	// A stale client at f_client (< horizon) gets a full snapshot:
+	// piece 5 in full_pieces, removed is empty.
+	auto const r = ph.query(f_client);
+	BOOST_TEST(r.is_snapshot);
+	BOOST_TEST(r.removed.empty());
+	BOOST_TEST(r.full_pieces.size() == 1u);
+	if (!r.full_pieces.empty())
+		BOOST_TEST((r.full_pieces[0]->piece_index == lt::piece_index_t(5)));
+}
+
+// Before any eviction the horizon is 0 and deltas work normally.
+BOOST_AUTO_TEST_CASE(horizon_zero_before_eviction)
+{
+	ltweb::piece_history ph(make_hash(0x11), 10);
+	BOOST_TEST(ph.horizon() == 0u);
+
+	fake_queue q1, q2;
+	q1.add(0, {1, 1});
+	auto const f1 = ph.update(q1.pieces);
+	ph.update(q2.pieces);  // piece 0 removed
+
+	// Still under the limit, so horizon stays 0.
+	BOOST_TEST(ph.horizon() == 0u);
+
+	// Normal delta: piece 0 should appear in removed.
+	auto const r = ph.query(f1);
+	BOOST_TEST(!r.is_snapshot);
+	BOOST_TEST(r.removed.size() == 1u);
 }

--- a/tests/test_torrent_history.cpp
+++ b/tests/test_torrent_history.cpp
@@ -105,9 +105,8 @@ BOOST_AUTO_TEST_CASE(integration)
 
 	// All three torrents must appear in the history
 	{
-		std::vector<lt::torrent_status> all;
-		history.updated_since(0, all);
-		BOOST_TEST(all.size() == 3);
+		auto const r = history.query(0);
+		BOOST_TEST(r.updated.size() == 3);
 	}
 
 	// v1-only lookup by sha1 hash
@@ -116,13 +115,12 @@ BOOST_AUTO_TEST_CASE(integration)
 		BOOST_TEST((st.info_hashes == lt::info_hash_t(v1_hash)));
 	}
 
-	// Hybrid torrent appears in updated_since
+	// Hybrid torrent appears in query
 	{
-		std::vector<lt::torrent_status> all;
-		history.updated_since(0, all);
+		auto const r = history.query(0);
 		bool found_hybrid = false;
-		for (auto const& s : all)
-			if (s.info_hashes == lt::info_hash_t(hy_v1, hy_v2))
+		for (auto const& e : r.updated)
+			if (e.status.info_hashes == lt::info_hash_t(hy_v1, hy_v2))
 				found_hybrid = true;
 		BOOST_TEST(found_hybrid);
 	}
@@ -142,38 +140,36 @@ BOOST_AUTO_TEST_CASE(integration)
 		BOOST_TEST(f > frame_before_update);
 	}
 
-	// updated_since with the current frame returns nothing new
+	// query with the current frame returns nothing new
 	{
 		ltweb::frame_t const f = history.frame();
-		std::vector<lt::torrent_status> empty;
-		history.updated_since(f, empty);
-		BOOST_TEST(empty.empty());
+		auto const r = history.query(f);
+		BOOST_TEST(r.updated.empty());
 	}
 
-	// Removing a torrent records it in removed_since
+	// Removing a torrent records it in query().removed
 	{
 		ltweb::frame_t const f = history.frame();
 		ses.remove_torrent(h1);
 		wait_for(ses, handler, 1, lt::torrent_removed_alert::alert_type);
 
-		auto const removed = history.removed_since(f);
-		BOOST_TEST(removed.size() == 1);
-		if (!removed.empty())
-			BOOST_TEST((removed[0] == v1_hash));
+		auto const r = history.query(f);
+		BOOST_TEST(r.removed.size() == 1);
+		if (!r.removed.empty())
+			BOOST_TEST((r.removed[0] == v1_hash));
 	}
 
-	// After removal the torrent no longer shows up in updated_since
+	// After removal the torrent no longer shows up in query
 	{
-		std::vector<lt::torrent_status> remaining;
-		history.updated_since(0, remaining);
-		BOOST_TEST(remaining.size() == 2);
-		for (auto const& s : remaining)
-			BOOST_TEST((s.info_hashes != lt::info_hash_t(v1_hash)));
+		auto const r = history.query(0);
+		BOOST_TEST(r.updated.size() == 2);
+		for (auto const& e : r.updated)
+			BOOST_TEST((e.status.info_hashes != lt::info_hash_t(v1_hash)));
 	}
 }
 
 // A torrent that is added and removed between two client polls should not
-// appear in removed_since() for a client whose last frame predates the add.
+// appear in "removed" for a client whose last frame predates the add.
 BOOST_AUTO_TEST_CASE(removed_before_client_saw_add)
 {
 	lt::session ses(make_settings_pack());
@@ -203,15 +199,75 @@ BOOST_AUTO_TEST_CASE(removed_before_client_saw_add)
 
 	// A client at f0 never saw the torrent — it should not receive a removal.
 	{
-		auto const removed = history.removed_since(f0);
-		BOOST_TEST(removed.empty());
+		auto const r = history.query(f0);
+		BOOST_TEST(r.removed.empty());
 	}
 
 	// A client at f1 (after the add) should receive the removal.
 	{
-		auto const removed = history.removed_since(f1);
-		BOOST_TEST(removed.size() == 1);
-		if (!removed.empty())
-			BOOST_TEST((removed[0] == make_v1(0xbb)));
+		auto const r = history.query(f1);
+		BOOST_TEST(r.removed.size() == 1);
+		if (!r.removed.empty())
+			BOOST_TEST((r.removed[0] == make_v1(0xbb)));
+	}
+}
+
+// When tombstones overflow the limit they are evicted and the horizon advances.
+// Any query with since_frame < horizon() must be treated as a full snapshot
+BOOST_AUTO_TEST_CASE(horizon_after_tombstone_eviction)
+{
+	lt::session ses(make_settings_pack());
+
+	ltweb::alert_handler handler(ses);
+	// Limit tombstones to 2 so that the third removal triggers eviction.
+	ltweb::torrent_history history(&handler, 2);
+
+	lt::add_torrent_params p;
+	p.save_path = ".";
+
+	// Add four torrents; h4 will survive all removals and act as a witness.
+	p.info_hashes = lt::info_hash_t(make_v1(0x0a));
+	lt::torrent_handle h1 = ses.add_torrent(p);
+	p.info_hashes = lt::info_hash_t(make_v1(0x0b));
+	lt::torrent_handle h2 = ses.add_torrent(p);
+	p.info_hashes = lt::info_hash_t(make_v1(0x0c));
+	lt::torrent_handle h3 = ses.add_torrent(p);
+	p.info_hashes = lt::info_hash_t(make_v1(0x0d));
+	lt::torrent_handle h4 = ses.add_torrent(p);
+	(void)h4;
+	wait_for(ses, handler, 4, lt::add_torrent_alert::alert_type);
+
+	ses.post_torrent_updates();
+	wait_for(ses, handler, 1, lt::state_update_alert::alert_type);
+	ltweb::frame_t const f_client = history.frame();
+
+	// Before any removals the horizon is 0.
+	BOOST_TEST(history.horizon() == 0u);
+
+	// Remove three of the four; the third removal pushes m_removed past the
+	// limit of 2, evicting the oldest tombstone and advancing the horizon.
+	ses.remove_torrent(h1);
+	ses.remove_torrent(h2);
+	ses.remove_torrent(h3);
+	wait_for(ses, handler, 3, lt::torrent_removed_alert::alert_type);
+
+	BOOST_TEST(history.horizon() > 0u);
+
+	// A stale client (f_client < horizon) gets a snapshot: removed is empty
+	// (since_frame clamped to 0; no added_frame satisfies added_frame <= 0).
+	{
+		auto const r = history.query(f_client);
+		BOOST_TEST(r.is_snapshot);
+		BOOST_TEST(r.removed.empty());
+		// updated contains all live torrents (just h4); clamping to 0 is
+		// what makes it return h4 rather than nothing.
+		BOOST_TEST(r.updated.size() == 1u);
+	}
+
+	// Consistent with a genuine snapshot query (frame == 0).
+	{
+		auto const r = history.query(0);
+		BOOST_TEST(r.is_snapshot);
+		BOOST_TEST(r.updated.size() == 1u);
 	}
 }


### PR DESCRIPTION
to evict tombstones and track our horizon, which we can't see beyond in queries. correctly promote any such queries to full snapshots