### PR TITLE
Make torrent history snapshots return a consistent frame

### DIFF
--- a/src/libtorrent_webui.cpp
+++ b/src/libtorrent_webui.cpp
@@ -345,7 +345,7 @@ namespace {
 		write_uint8(no_error, ptr);
 
 		// frame number (uint32)
-		write_uint32(m_hist.frame(), ptr);
+		write_uint32(r.current_frame, ptr);
 
 		// allocate space for torrent count
 		// this will be filled in later when we know
@@ -1577,4 +1577,3 @@ namespace {
 		return st->send_packet(rpc, sizeof(rpc));
 	}
 }
-

--- a/src/torrent_history.cpp
+++ b/src/torrent_history.cpp
@@ -113,6 +113,7 @@ namespace ltweb
 	{
 		query_result result;
 		std::unique_lock<std::mutex> l(m_mutex);
+		result.current_frame = current_frame_locked();
 		if (since_frame < m_horizon) since_frame = 0;
 		result.is_snapshot = (since_frame == 0);
 
@@ -156,6 +157,11 @@ namespace ltweb
 	frame_t torrent_history::frame() const
 	{
 		std::unique_lock<std::mutex> l(m_mutex);
+		return current_frame_locked();
+	}
+
+	frame_t torrent_history::current_frame_locked() const
+	{
 		if (m_deferred_frame_count)
 		{
 			m_deferred_frame_count = false;
@@ -325,4 +331,3 @@ namespace {
 		os << "\x1b[0m\n";
 	}
 }
-

--- a/src/torrent_history.hpp
+++ b/src/torrent_history.hpp
@@ -145,6 +145,8 @@ namespace ltweb
 
 		struct query_result
 		{
+			// Exact frame number captured under the same lock as updated/removed.
+			frame_t current_frame = 0;
 			bool is_snapshot = false;
 			std::vector<torrent_history_entry> updated;
 			std::vector<lt::sha1_hash> removed;
@@ -170,6 +172,11 @@ namespace ltweb
 		virtual void handle_alert(lt::alert const* a);
 
 	private:
+
+		// Returns the current frame while holding m_mutex. If add/remove alerts
+		// are pending in the deferred frame slot, consume that slot first so the
+		// returned frame matches the frames stored on those entries.
+		frame_t current_frame_locked() const;
 
 		// first is the frame this torrent was last
 		// seen modified in, second is the information
@@ -215,4 +222,3 @@ namespace ltweb
 }
 
 #endif
-

--- a/src/utorrent_webui.cpp
+++ b/src/utorrent_webui.cpp
@@ -1216,7 +1216,7 @@ void utorrent_webui::send_torrent_list(std::vector<char>& response, char const* 
 		appendf(response, "\"%s\"", to_hex(i).c_str());
 	}
 	// TODO: support labels
-	appendf(response, "], \"label\": [], \"torrentc\": \"%" PRIu32 "\"", m_hist.frame());
+	appendf(response, "], \"label\": [], \"torrentc\": \"%" PRIu32 "\"", r.current_frame);
 }
 
 void utorrent_webui::send_rss_list(std::vector<char>& response, char const* args, permissions_interface const* p)
@@ -1246,4 +1246,3 @@ std::vector<lt::torrent_status> utorrent_webui::parse_torrents(char const* args)
 }
 
 }
-

--- a/tests/test_torrent_history.cpp
+++ b/tests/test_torrent_history.cpp
@@ -212,6 +212,57 @@ BOOST_AUTO_TEST_CASE(removed_before_client_saw_add)
 	}
 }
 
+// query() must advance any deferred add/remove frame under the same lock as
+// the payload snapshot, so the returned frame can be used as the next poll
+// cursor without duplicating or skipping those events.
+BOOST_AUTO_TEST_CASE(query_current_frame_matches_deferred_snapshot)
+{
+	lt::session ses(make_settings_pack());
+
+	ltweb::alert_handler handler(ses);
+	ltweb::torrent_history history(&handler);
+
+	lt::add_torrent_params p;
+	p.save_path = ".";
+	lt::sha1_hash const ih = make_v1(0xaa);
+	p.info_hashes = lt::info_hash_t(ih);
+
+	ltweb::frame_t const f0 = history.frame();
+
+	lt::torrent_handle h = ses.add_torrent(p);
+	wait_for(ses, handler, 1, lt::add_torrent_alert::alert_type);
+
+	auto const added = history.query(f0);
+	BOOST_TEST(added.current_frame > f0);
+	BOOST_TEST(added.updated.size() == 1u);
+	if (!added.updated.empty())
+		BOOST_TEST((added.updated[0].status.info_hashes == lt::info_hash_t(ih)));
+	BOOST_TEST(history.frame() == added.current_frame);
+
+	{
+		auto const r = history.query(added.current_frame);
+		BOOST_TEST(r.updated.empty());
+		BOOST_TEST(r.removed.empty());
+	}
+
+	ses.remove_torrent(h);
+	wait_for(ses, handler, 1, lt::torrent_removed_alert::alert_type);
+
+	auto const removed = history.query(added.current_frame);
+	BOOST_TEST(removed.current_frame > added.current_frame);
+	BOOST_TEST(removed.updated.empty());
+	BOOST_TEST(removed.removed.size() == 1u);
+	if (!removed.removed.empty())
+		BOOST_TEST((removed.removed[0] == ih));
+	BOOST_TEST(history.frame() == removed.current_frame);
+
+	{
+		auto const r = history.query(removed.current_frame);
+		BOOST_TEST(r.updated.empty());
+		BOOST_TEST(r.removed.empty());
+	}
+}
+
 // When tombstones overflow the limit they are evicted and the horizon advances.
 // Any query with since_frame < horizon() must be treated as a full snapshot
 BOOST_AUTO_TEST_CASE(horizon_after_tombstone_eviction)


### PR DESCRIPTION
torrent_history::query() was returning updated and removed entries from one locked snapshot, but callers could still advance to a newer frame afterward by calling frame() separately.

That meant a client could store a cursor that did not actually match the payload it had just received, which could cause deferred add/remove events to be skipped on the next poll.

This change returns the exact frame captured with the snapshot and uses it in both the native webui and the utorrent-compatible response path. It also adds a regression test covering deferred add/remove events and next-poll cursor behavior.