### PR TITLE
Fix clang format

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
         # Only format this project's own C++ sources.  The vendored C code
         # (src/jsmn.*, src/cdecode.*) and the libtorrent submodule are
         # excluded by the path/extension filter below.
-        files: ^(src|tests)/.*\.(cpp|hpp)$
+        files: ^(src|tests|tools)/.*\.(cpp|hpp)$
 
   - repo: https://github.com/pre-commit/mirrors-prettier
     rev: v3.1.0

--- a/Jamfile
+++ b/Jamfile
@@ -7,7 +7,7 @@ feature pam : off on : composite ;
 
 feature use-boost : system source : composite ;
 
-project libtorrent-webui : requirements <cxxstd>17 ;
+project libtorrent-webui : requirements <cxxstd>20 ;
 
 use-project /torrent : libtorrent ;
 lib sqlite : : <name>sqlite3 <search>/opt/local/lib : <include>/opt/local/include ;
@@ -60,7 +60,7 @@ lib torrent-webui
 
 	: # default build
 	<link>static
-	<cxxstd>17
+	<cxxstd>20
 
 	: # usage-requirements
 	<include>src
@@ -75,9 +75,9 @@ lib rt : : <name>rt <search>/usr/local/lib <link>shared ;
 lib pam : : <name>pam <search>/usr/local/lib ;
 lib dynamic-linker : : <name>dl <link>shared ;
 
-exe webui_test : test.cpp : <library>torrent-webui <library>/torrent//torrent <cxxstd>17 ;
+exe webui_test : test.cpp : <library>torrent-webui <library>/torrent//torrent <cxxstd>20 ;
 install stage_webui_test : webui_test : <location>. ;
 
-exe add_user : tools/add_user.cpp : <library>torrent-webui <library>/torrent//torrent <cxxstd>17 ;
+exe add_user : tools/add_user.cpp : <library>torrent-webui <library>/torrent//torrent <cxxstd>20 ;
 install stage_add_user : add_user : <location>. ;
 

--- a/src/torrent_history.cpp
+++ b/src/torrent_history.cpp
@@ -235,11 +235,6 @@ std::ostream& operator<<(std::ostream& os, lt::torrent_status::state_t s)
 	return os << static_cast<int>(s);
 }
 
-std::ostream& operator<<(std::ostream& os, lt::time_duration const d)
-{
-	return os << std::chrono::duration_cast<std::chrono::seconds>(d).count();
-}
-
 std::ostream& operator<<(std::ostream& os, lt::time_point const t)
 {
 	return os << std::chrono::duration_cast<std::chrono::seconds>(t.time_since_epoch()).count();

--- a/tools/add_user.cpp
+++ b/tools/add_user.cpp
@@ -6,13 +6,15 @@ using namespace ltweb;
 
 int main(int argc, char* argv[])
 {
-	if (argc != 3 || atoi(argv[2]) < 0 || atoi(argv[2]) > 10000)
-	{
-		fprintf(stderr, "usage:\n"
+	if (argc != 3 || atoi(argv[2]) < 0 || atoi(argv[2]) > 10000) {
+		fprintf(
+			stderr,
+			"usage:\n"
 			"add_user username group-number\n\n"
 			"the user is added to users.conf in\n"
 			"current working directory.\n"
-			"group numbers may not be negative.\n");
+			"group numbers may not be negative.\n"
+		);
 		return 1;
 	}
 
@@ -21,12 +23,10 @@ int main(int argc, char* argv[])
 	char password[1024];
 	printf("enter password: ");
 	fflush(stdout);
-	if (fgets(password, 1024, stdin) == NULL)
-		return 1;
+	if (fgets(password, 1024, stdin) == NULL) return 1;
 
 	int pwdlen = strlen(password);
-	while (pwdlen > 0 && password[pwdlen-1] == '\n')
-	{
+	while (pwdlen > 0 && password[pwdlen - 1] == '\n') {
 		--pwdlen;
 		password[pwdlen] = '\0';
 	}
@@ -36,10 +36,8 @@ int main(int argc, char* argv[])
 	authorizer.add_account(argv[1], password, atoi(argv[2]));
 	ec.clear();
 	authorizer.save_accounts("./users.conf", ec);
-	if (ec)
-	{
+	if (ec) {
 		fprintf(stderr, "failed to save users file: %s\n", ec.message().c_str());
 	}
 	return 0;
 }
-


### PR DESCRIPTION
add `tools/` to clang format config
bump C++ dependency to C++20.
remove unused function (to fix warning).