### PR TITLE
move permissions classes to its own translation unit

### DIFF
--- a/Jamfile
+++ b/Jamfile
@@ -33,6 +33,7 @@ SOURCES =
 	torrent_history
 	piece_history
 	no_auth
+	perms
 	session_authenticator
 	sqlite_user_account
 	parse_http_auth

--- a/src/auth_interface.hpp
+++ b/src/auth_interface.hpp
@@ -10,88 +10,28 @@ see LICENSE file.
 #ifndef LTWEB_PERM_INTERFACE_HPP
 #define LTWEB_PERM_INTERFACE_HPP
 
-#include <cctype>
 #include <optional>
-#include <string>
 #include <string_view>
-#include <utility>
 
-#include "base64.hpp"
+#include "perms.hpp"
 
 namespace ltweb {
 
 /**
-	This is the interface an object need to implement in order
-	to specify custom access permissions.
-*/
-struct permissions_interface {
-	/// If returning true, the user may start torrents
-	virtual bool allow_start() const = 0;
+	The interface to an authentication module. This plugs into web
+	interfaces to authenticate requests and determine their access
+	permissions.
 
-	/// If returning true, the user may stop torrents
-	virtual bool allow_stop() const = 0;
+	The header string is passed in already extracted, so this
+	interface stays transport-agnostic and avoids depending on Beast.
 
-	/// If returning true, the user may re-check torrents
-	virtual bool allow_recheck() const = 0;
-
-	/// If returning true, the user may modifiy the priority of files
-	virtual bool allow_set_file_prio() const = 0;
-
-	/// If returning true, the user may list torrents
-	// TODO: separate this out to listing torrents and listing files
-	virtual bool allow_list() const = 0;
-
-	/// If returning true, the user may add torrents
-	virtual bool allow_add() const = 0;
-
-	/// If returning true, the user may remove torrents
-	virtual bool allow_remove() const = 0;
-
-	/// If returning true, the user may remove torrents
-	/// and delete their data from disk
-	virtual bool allow_remove_data() const = 0;
-
-	/// If returning true, the user may queue-up or -down torrents torrents
-	virtual bool allow_queue_change() const = 0;
-
-	/// If returning true, the user may GET the specified setting
-	/// name is the constant used in lt::settings_pack or -1 for
-	/// settings that don't fit a libtorrent setting
-	virtual bool allow_get_settings(int name) const = 0;
-
-	/// If returning true, the user may SET the specified setting
-	/// name is the constant used in lt::settings_pack or -1 for
-	/// settings that don't fit a libtorrent setting
-	virtual bool allow_set_settings(int name) const = 0;
-
-	/// If returning true, the user may download the content of torrents
-	virtual bool allow_get_data() const = 0;
-
-	// TODO: separate permissions to alter torrent state. separate different categories of settings?
-	/// If returning true, the user is allowed to query session status,
-	/// like global upload and download rates
-	virtual bool allow_session_status() const = 0;
-};
-
-/**
-  The interface to an authentication module. This plugs into web
-  interfaces to authenticate requests and determine their access
-  permissions. Implementations decide which schemes are honored
-  (session cookies, HTTP Basic, etc) by inspecting the two header
-  values passed in.
-
-  The header strings are passed in already extracted, so this
-  interface stays transport-agnostic and avoids depending on Beast.
-
-	session_cookie: value of the session cookie, or empty if absent.
-	authorization:  value of the Authorization header, or empty.
+	session_cookie: value of the session cookie
 
 	Returns the permissions for the authenticated request, or nullptr
 	if authentication failed.
 */
 struct auth_interface {
-	virtual permissions_interface const*
-	authenticate(std::string_view session_cookie, std::string_view authorization) const = 0;
+	virtual permissions_interface const* authenticate(std::string_view session_cookie) const = 0;
 };
 
 // A directory of user accounts. Implementations look up the username,
@@ -103,94 +43,6 @@ struct auth_interface {
 struct user_account {
 	virtual std::optional<int>
 	verify(std::string_view username, std::string_view password) const = 0;
-};
-
-// Helper for implementations of auth_interface that support HTTP
-// Basic Auth. Parses "Basic <base64(user:pass)>" from an
-// Authorization header value and returns the decoded (user, pwd)
-// pair. Returns ("", "") when the header is empty or uses any
-// other scheme - implementations typically treat that as anonymous
-// and dispatch on whether such access is allowed.
-inline std::pair<std::string, std::string> parse_basic_auth(std::string_view authorization)
-{
-	// Strip leading whitespace; HTTP parsers usually do this but we
-	// cannot assume it for an arbitrary string_view.
-	while (!authorization.empty() && (authorization.front() == ' ' || authorization.front() == '\t')
-	)
-		authorization.remove_prefix(1);
-
-	// Case-insensitive check for "basic" followed by whitespace.
-	if (authorization.size() < 6) return {};
-	static constexpr char tag[] = "basic";
-	for (int i = 0; i < 5; ++i)
-		if (std::tolower(static_cast<unsigned char>(authorization[i])) != tag[i]) return {};
-	if (authorization[5] != ' ' && authorization[5] != '\t') return {};
-
-	authorization.remove_prefix(5);
-	while (!authorization.empty() && (authorization.front() == ' ' || authorization.front() == '\t')
-	)
-		authorization.remove_prefix(1);
-
-	std::string cred = base64decode(std::string(authorization));
-	auto const colon = cred.find(':');
-	if (colon == std::string::npos) return {std::move(cred), {}};
-	return {cred.substr(0, colon), cred.substr(colon + 1)};
-}
-
-/// an implementation of permissions_interface that reject all access
-struct no_permissions : permissions_interface {
-	no_permissions() {}
-	bool allow_start() const override { return false; }
-	bool allow_stop() const override { return false; }
-	bool allow_recheck() const override { return false; }
-	bool allow_set_file_prio() const override { return false; }
-	bool allow_list() const override { return false; }
-	bool allow_add() const override { return false; }
-	bool allow_remove() const override { return false; }
-	bool allow_remove_data() const override { return false; }
-	bool allow_queue_change() const override { return false; }
-	bool allow_get_settings(int) const override { return false; }
-	bool allow_set_settings(int) const override { return false; }
-	bool allow_get_data() const override { return false; }
-	bool allow_session_status() const override { return false; }
-};
-
-/// an implementation of permissions_interface that only allow inspecting
-/// the stat of the torrent client, not altering it in any way. No modification
-/// of settings, no adding/removing/rechecking of torrents.
-struct read_only_permissions : permissions_interface {
-	read_only_permissions() {}
-	bool allow_start() const override { return false; }
-	bool allow_stop() const override { return false; }
-	bool allow_recheck() const override { return false; }
-	bool allow_set_file_prio() const override { return false; }
-	bool allow_list() const override { return true; }
-	bool allow_add() const override { return false; }
-	bool allow_remove() const override { return false; }
-	bool allow_remove_data() const override { return false; }
-	bool allow_queue_change() const override { return false; }
-	bool allow_get_settings(int) const override { return true; }
-	bool allow_set_settings(int) const override { return false; }
-	bool allow_get_data() const override { return true; }
-	bool allow_session_status() const override { return true; }
-};
-
-/// an implementation of permissions_interface that permit all access.
-struct full_permissions : permissions_interface {
-	full_permissions() {}
-	bool allow_start() const override { return true; }
-	bool allow_stop() const override { return true; }
-	bool allow_recheck() const override { return true; }
-	bool allow_set_file_prio() const override { return true; }
-	bool allow_list() const override { return true; }
-	bool allow_add() const override { return true; }
-	bool allow_remove() const override { return true; }
-	bool allow_remove_data() const override { return true; }
-	bool allow_queue_change() const override { return true; }
-	bool allow_get_settings(int) const override { return true; }
-	bool allow_set_settings(int) const override { return true; }
-	bool allow_get_data() const override { return true; }
-	bool allow_session_status() const override { return true; }
 };
 
 } // namespace ltweb

--- a/src/parse_http_auth.cpp
+++ b/src/parse_http_auth.cpp
@@ -40,17 +40,13 @@ std::string_view extract_cookie(std::string_view cookie_header, std::string_view
 permissions_interface const*
 parse_http_auth(http::request<http::string_body> const& request, auth_interface const& auth)
 {
-	std::string_view authorization;
-	auto const auth_it = request.find(http::field::authorization);
-	if (auth_it != request.end()) authorization = auth_it->value();
-
 	std::string_view session_cookie;
 	auto const cookie_it = request.find(http::field::cookie);
 	if (cookie_it != request.end()) {
 		session_cookie = extract_cookie(cookie_it->value(), "session");
 	}
 
-	return auth.authenticate(session_cookie, authorization);
+	return auth.authenticate(session_cookie);
 }
 
 } // namespace ltweb

--- a/src/parse_http_auth.hpp
+++ b/src/parse_http_auth.hpp
@@ -20,10 +20,8 @@ namespace http = boost::beast::http;
 
 namespace ltweb {
 
-// Extract the session cookie value and Authorization header from a
-// Beast request and forward to auth.authenticate(). All scheme-
-// specific parsing (Basic, sessions, ...) lives inside the
-// auth_interface implementation.
+// Extract the session cookie value from a Beast request and forward to
+// auth.authenticate().
 permissions_interface const*
 parse_http_auth(http::request<http::string_body> const& request, auth_interface const& auth);
 

--- a/src/perms.cpp
+++ b/src/perms.cpp
@@ -1,0 +1,146 @@
+/*
+
+Copyright (c) 2013, 2020, 2026, Arvid Norberg
+All rights reserved.
+
+You may use, distribute and modify this code under the terms of the BSD license,
+see LICENSE file.
+*/
+
+#include "perms.hpp"
+
+#include <libtorrent/settings_pack.hpp>
+
+namespace ltweb {
+
+namespace {
+bool is_local_setting(int name)
+{
+	switch (name) {
+		// identity sent to peers and trackers
+		case libtorrent::settings_pack::user_agent:
+		case libtorrent::settings_pack::handshake_client_version:
+		case libtorrent::settings_pack::peer_fingerprint:
+		case libtorrent::settings_pack::announce_ip:
+		case libtorrent::settings_pack::announce_port:
+
+		// local network interfaces and ports
+		case libtorrent::settings_pack::listen_interfaces:
+		case libtorrent::settings_pack::outgoing_interfaces:
+		case libtorrent::settings_pack::outgoing_port:
+		case libtorrent::settings_pack::num_outgoing_ports:
+		case libtorrent::settings_pack::listen_queue_size:
+		case libtorrent::settings_pack::listen_system_port_fallback:
+		case libtorrent::settings_pack::max_retry_port_bind:
+		case libtorrent::settings_pack::peer_dscp:
+
+		// proxy configuration
+		case libtorrent::settings_pack::proxy_hostname:
+		case libtorrent::settings_pack::proxy_username:
+		case libtorrent::settings_pack::proxy_password:
+		case libtorrent::settings_pack::proxy_type:
+		case libtorrent::settings_pack::proxy_port:
+		case libtorrent::settings_pack::proxy_hostnames:
+		case libtorrent::settings_pack::proxy_peer_connections:
+		case libtorrent::settings_pack::proxy_tracker_connections:
+		case libtorrent::settings_pack::proxy_send_host_in_connect:
+		case libtorrent::settings_pack::socks5_udp_send_local_ep:
+
+		// I2P SAM bridge
+		case libtorrent::settings_pack::i2p_hostname:
+		case libtorrent::settings_pack::i2p_port:
+		case libtorrent::settings_pack::i2p_inbound_quantity:
+		case libtorrent::settings_pack::i2p_outbound_quantity:
+		case libtorrent::settings_pack::i2p_inbound_length:
+		case libtorrent::settings_pack::i2p_outbound_length:
+		case libtorrent::settings_pack::i2p_inbound_length_variance:
+		case libtorrent::settings_pack::i2p_outbound_length_variance:
+		case libtorrent::settings_pack::allow_i2p_mixed:
+
+		// NAT-PMP / PCP / UPnP port mapping
+		case libtorrent::settings_pack::natpmp_gateway:
+		case libtorrent::settings_pack::natpmp_lease_duration:
+		case libtorrent::settings_pack::upnp_lease_duration:
+		case libtorrent::settings_pack::upnp_ignore_nonrouters:
+		case libtorrent::settings_pack::enable_upnp:
+		case libtorrent::settings_pack::enable_natpmp:
+
+		// local network discovery
+		case libtorrent::settings_pack::enable_lsd:
+		case libtorrent::settings_pack::local_service_announce_interval:
+
+		// DHT bootstrap and WebTorrent infrastructure
+		case libtorrent::settings_pack::dht_bootstrap_nodes:
+		case libtorrent::settings_pack::webtorrent_stun_server:
+
+		// OS-level resources and filesystem behavior
+		case libtorrent::settings_pack::aio_threads:
+		case libtorrent::settings_pack::hashing_threads:
+		case libtorrent::settings_pack::file_pool_size:
+		case libtorrent::settings_pack::enable_ip_notifier:
+		case libtorrent::settings_pack::no_atime_storage:
+		case libtorrent::settings_pack::disk_disable_copy_on_write:
+		case libtorrent::settings_pack::enable_set_file_valid_data:
+			return true;
+	}
+	return false;
+}
+} // namespace
+
+bool no_permissions::allow_start() const { return false; }
+bool no_permissions::allow_stop() const { return false; }
+bool no_permissions::allow_recheck() const { return false; }
+bool no_permissions::allow_set_file_prio() const { return false; }
+bool no_permissions::allow_list() const { return false; }
+bool no_permissions::allow_add() const { return false; }
+bool no_permissions::allow_remove() const { return false; }
+bool no_permissions::allow_remove_data() const { return false; }
+bool no_permissions::allow_queue_change() const { return false; }
+bool no_permissions::allow_get_settings(int) const { return false; }
+bool no_permissions::allow_set_settings(int) const { return false; }
+bool no_permissions::allow_get_data() const { return false; }
+bool no_permissions::allow_session_status() const { return false; }
+
+bool read_only_permissions::allow_start() const { return false; }
+bool read_only_permissions::allow_stop() const { return false; }
+bool read_only_permissions::allow_recheck() const { return false; }
+bool read_only_permissions::allow_set_file_prio() const { return false; }
+bool read_only_permissions::allow_list() const { return true; }
+bool read_only_permissions::allow_add() const { return false; }
+bool read_only_permissions::allow_remove() const { return false; }
+bool read_only_permissions::allow_remove_data() const { return false; }
+bool read_only_permissions::allow_queue_change() const { return false; }
+bool read_only_permissions::allow_get_settings(int) const { return true; }
+bool read_only_permissions::allow_set_settings(int) const { return false; }
+bool read_only_permissions::allow_get_data() const { return true; }
+bool read_only_permissions::allow_session_status() const { return true; }
+
+bool full_permissions::allow_start() const { return true; }
+bool full_permissions::allow_stop() const { return true; }
+bool full_permissions::allow_recheck() const { return true; }
+bool full_permissions::allow_set_file_prio() const { return true; }
+bool full_permissions::allow_list() const { return true; }
+bool full_permissions::allow_add() const { return true; }
+bool full_permissions::allow_remove() const { return true; }
+bool full_permissions::allow_remove_data() const { return true; }
+bool full_permissions::allow_queue_change() const { return true; }
+bool full_permissions::allow_get_settings(int) const { return true; }
+bool full_permissions::allow_set_settings(int) const { return true; }
+bool full_permissions::allow_get_data() const { return true; }
+bool full_permissions::allow_session_status() const { return true; }
+
+bool remote_user::allow_start() const { return true; }
+bool remote_user::allow_stop() const { return true; }
+bool remote_user::allow_recheck() const { return true; }
+bool remote_user::allow_set_file_prio() const { return true; }
+bool remote_user::allow_list() const { return true; }
+bool remote_user::allow_add() const { return true; }
+bool remote_user::allow_remove() const { return true; }
+bool remote_user::allow_remove_data() const { return true; }
+bool remote_user::allow_queue_change() const { return true; }
+bool remote_user::allow_get_settings(int name) const { return !is_local_setting(name); }
+bool remote_user::allow_set_settings(int name) const { return !is_local_setting(name); }
+bool remote_user::allow_get_data() const { return true; }
+bool remote_user::allow_session_status() const { return true; }
+
+} // namespace ltweb

--- a/src/perms.hpp
+++ b/src/perms.hpp
@@ -1,0 +1,145 @@
+/*
+
+Copyright (c) 2013, 2020, 2026, Arvid Norberg
+All rights reserved.
+
+You may use, distribute and modify this code under the terms of the BSD license,
+see LICENSE file.
+*/
+
+#ifndef LTWEB_PERMS_HPP
+#define LTWEB_PERMS_HPP
+
+namespace ltweb {
+
+// This is the interface an object needs to implement in order
+// to specify custom access permissions.
+struct permissions_interface {
+	// If returning true, the user may start torrents
+	virtual bool allow_start() const = 0;
+
+	// If returning true, the user may stop torrents
+	virtual bool allow_stop() const = 0;
+
+	// If returning true, the user may re-check torrents
+	virtual bool allow_recheck() const = 0;
+
+	// If returning true, the user may modify the priority of files
+	virtual bool allow_set_file_prio() const = 0;
+
+	// If returning true, the user may list torrents
+	// TODO: separate this out to listing torrents and listing files
+	virtual bool allow_list() const = 0;
+
+	// If returning true, the user may add torrents
+	virtual bool allow_add() const = 0;
+
+	// If returning true, the user may remove torrents
+	virtual bool allow_remove() const = 0;
+
+	// If returning true, the user may remove torrents
+	// and delete their data from disk
+	virtual bool allow_remove_data() const = 0;
+
+	// If returning true, the user may queue-up or -down torrents
+	virtual bool allow_queue_change() const = 0;
+
+	// If returning true, the user may GET the specified setting
+	// name is the constant used in lt::settings_pack or -1 for
+	// settings that don't fit a libtorrent setting
+	virtual bool allow_get_settings(int name) const = 0;
+
+	// If returning true, the user may SET the specified setting
+	// name is the constant used in lt::settings_pack or -1 for
+	// settings that don't fit a libtorrent setting
+	virtual bool allow_set_settings(int name) const = 0;
+
+	// If returning true, the user may download the content of torrents
+	virtual bool allow_get_data() const = 0;
+
+	// TODO: separate permissions to alter torrent state. separate different categories of settings?
+	// If returning true, the user is allowed to query session status,
+	// like global upload and download rates
+	virtual bool allow_session_status() const = 0;
+};
+
+// an implementation of permissions_interface that rejects all access
+struct no_permissions : permissions_interface {
+	bool allow_start() const override;
+	bool allow_stop() const override;
+	bool allow_recheck() const override;
+	bool allow_set_file_prio() const override;
+	bool allow_list() const override;
+	bool allow_add() const override;
+	bool allow_remove() const override;
+	bool allow_remove_data() const override;
+	bool allow_queue_change() const override;
+	bool allow_get_settings(int) const override;
+	bool allow_set_settings(int) const override;
+	bool allow_get_data() const override;
+	bool allow_session_status() const override;
+};
+
+// an implementation of permissions_interface that only allow inspecting
+// the state of the torrent client, not altering it in any way. No modification
+// of settings, no adding/removing/rechecking of torrents.
+struct read_only_permissions : permissions_interface {
+	bool allow_start() const override;
+	bool allow_stop() const override;
+	bool allow_recheck() const override;
+	bool allow_set_file_prio() const override;
+	bool allow_list() const override;
+	bool allow_add() const override;
+	bool allow_remove() const override;
+	bool allow_remove_data() const override;
+	bool allow_queue_change() const override;
+	bool allow_get_settings(int) const override;
+	bool allow_set_settings(int) const override;
+	bool allow_get_data() const override;
+	bool allow_session_status() const override;
+};
+
+// an implementation of permissions_interface that permit all access.
+struct full_permissions : permissions_interface {
+	bool allow_start() const override;
+	bool allow_stop() const override;
+	bool allow_recheck() const override;
+	bool allow_set_file_prio() const override;
+	bool allow_list() const override;
+	bool allow_add() const override;
+	bool allow_remove() const override;
+	bool allow_remove_data() const override;
+	bool allow_queue_change() const override;
+	bool allow_get_settings(int) const override;
+	bool allow_set_settings(int) const override;
+	bool allow_get_data() const override;
+	bool allow_session_status() const override;
+};
+
+// an implementation of permissions_interface for users connecting from a
+// remote machine. They have full access to the torrent client itself but
+// are denied access to settings that are inherently local to the host
+// running the daemon: network interfaces, proxy configuration, server
+// identity sent on the wire, NAT and port-mapping, local peer discovery,
+// and OS/filesystem-tuning knobs. A remote user generally has no way to
+// know what is sensible for these on the host, and some of them (proxy
+// credentials in particular) would leak host-side secrets if readable.
+struct remote_user : permissions_interface {
+	bool allow_start() const override;
+	bool allow_stop() const override;
+	bool allow_recheck() const override;
+	bool allow_set_file_prio() const override;
+	bool allow_list() const override;
+	bool allow_add() const override;
+	bool allow_remove() const override;
+	bool allow_remove_data() const override;
+	bool allow_queue_change() const override;
+	bool allow_get_settings(int name) const override;
+	bool allow_set_settings(int name) const override;
+	bool allow_get_data() const override;
+	bool allow_session_status() const override;
+};
+
+} // namespace ltweb
+
+#endif // LTWEB_PERMS_HPP

--- a/src/session_authenticator.cpp
+++ b/src/session_authenticator.cpp
@@ -37,8 +37,8 @@ session_authenticator::session_authenticator(std::chrono::seconds idle_timeout)
 {
 }
 
-permissions_interface const* session_authenticator::
-	authenticate(std::string_view session_cookie, std::string_view /*authorization*/) const
+permissions_interface const* session_authenticator::authenticate(std::string_view session_cookie
+) const
 {
 	if (session_cookie.empty()) return nullptr;
 

--- a/src/session_authenticator.hpp
+++ b/src/session_authenticator.hpp
@@ -41,10 +41,8 @@ struct session_authenticator : auth_interface {
 	explicit session_authenticator(std::chrono::seconds idle_timeout = std::chrono::hours(1));
 
 	// auth_interface: returns the session's permissions, or nullptr if
-	// the cookie is unknown or expired. The authorization parameter
-	// is part of the auth_interface signature but is not used here.
-	permissions_interface const*
-	authenticate(std::string_view session_cookie, std::string_view authorization) const override;
+	// the cookie is unknown or expired.
+	permissions_interface const* authenticate(std::string_view session_cookie) const override;
 
 	// Mint a new session bound to perms. Returns the cookie value to
 	// place in a Set-Cookie header (typically:

--- a/tests/test_parse_http_auth.cpp
+++ b/tests/test_parse_http_auth.cpp
@@ -20,34 +20,20 @@ using namespace ltweb;
 
 namespace {
 
-// Mock auth_interface that records both the raw arguments
-// authenticate() received and the decoded Basic credentials, and
+// Mock auth_interface that records the raw argument to authenticate() and
 // returns a pre-configured permissions pointer.
-//
-// Decoding is run inside the mock (using the same parse_basic_auth
-// helper that real implementations use) so tests can still assert on
-// "user" and "password" - this verifies the full chain: header
-// extraction in parse_http_auth + Basic decoding in the helper.
 struct mock_auth : auth_interface {
 	// set before each call to control the return value
 	permissions_interface const* result = nullptr;
 
 	// raw arguments passed to authenticate()
 	mutable std::string last_cookie;
-	mutable std::string last_authorization;
-
-	// decoded Basic credentials (or empty for non-Basic / no header)
-	mutable std::string last_user;
-	mutable std::string last_password;
 	mutable bool authenticate_called = false;
 
-	permissions_interface const*
-	authenticate(std::string_view session_cookie, std::string_view authorization) const override
+	permissions_interface const* authenticate(std::string_view session_cookie) const override
 	{
 		authenticate_called = true;
 		last_cookie = std::string(session_cookie);
-		last_authorization = std::string(authorization);
-		std::tie(last_user, last_password) = parse_basic_auth(authorization);
 		return result;
 	}
 };
@@ -65,124 +51,6 @@ full_permissions const g_full;
 
 } // anonymous namespace
 
-BOOST_AUTO_TEST_CASE(anonymous_rejected)
-{
-	// No Authorization header: authenticate("", "") is called, result propagated.
-	mock_auth auth;
-	auth.result = nullptr;
-	auto* p = parse_http_auth(make_request(), auth);
-	BOOST_TEST(p == nullptr);
-	BOOST_TEST(auth.authenticate_called);
-	BOOST_TEST(auth.last_authorization == "");
-	BOOST_TEST(auth.last_user == "");
-	BOOST_TEST(auth.last_password == "");
-}
-
-BOOST_AUTO_TEST_CASE(anonymous_accepted)
-{
-	// No Authorization header, auth accepts anonymous access.
-	mock_auth auth;
-	auth.result = &g_full;
-	auto* p = parse_http_auth(make_request(), auth);
-	BOOST_TEST(p == &g_full);
-	BOOST_TEST(auth.authenticate_called);
-	BOOST_TEST(auth.last_authorization == "");
-	BOOST_TEST(auth.last_user == "");
-	BOOST_TEST(auth.last_password == "");
-}
-
-BOOST_AUTO_TEST_CASE(valid_basic)
-{
-	// Valid "basic " credentials: "user:pass" -> base64 "dXNlcjpwYXNz"
-	mock_auth auth;
-	auth.result = &g_full;
-	auto* p = parse_http_auth(make_request("basic dXNlcjpwYXNz"), auth);
-	BOOST_TEST(p == &g_full);
-	BOOST_TEST(auth.last_authorization == "basic dXNlcjpwYXNz");
-	BOOST_TEST(auth.last_user == "user");
-	BOOST_TEST(auth.last_password == "pass");
-}
-
-BOOST_AUTO_TEST_CASE(colon_in_password)
-{
-	// Credentials with a colon in the password: "alice:p:ss" -> base64 "YWxpY2U6cDpzcw=="
-	// The split is on the first colon only, so the password is "p:ss".
-	mock_auth auth;
-	auth.result = &g_full;
-	auto* p = parse_http_auth(make_request("basic YWxpY2U6cDpzcw=="), auth);
-	BOOST_TEST(p == &g_full);
-	BOOST_TEST(auth.last_user == "alice");
-	BOOST_TEST(auth.last_password == "p:ss");
-}
-
-BOOST_AUTO_TEST_CASE(empty_password)
-{
-	// Empty password: "bob:" -> base64 "Ym9iOg=="
-	mock_auth auth;
-	auth.result = &g_full;
-	auto* p = parse_http_auth(make_request("basic Ym9iOg=="), auth);
-	BOOST_TEST(p == &g_full);
-	BOOST_TEST(auth.last_user == "bob");
-	BOOST_TEST(auth.last_password == "");
-}
-
-BOOST_AUTO_TEST_CASE(extra_whitespace)
-{
-	// Whitespace around the base64 token is trimmed: leading space after "basic ".
-	mock_auth auth;
-	auth.result = &g_full;
-	auto* p = parse_http_auth(make_request("basic  dXNlcjpwYXNz"), auth);
-	BOOST_TEST(p == &g_full);
-	BOOST_TEST(auth.last_user == "user");
-	BOOST_TEST(auth.last_password == "pass");
-}
-
-BOOST_AUTO_TEST_CASE(wrong_scheme)
-{
-	// Wrong scheme ("Bearer"): not parsed as Basic, last_user/password empty.
-	// The raw header is still forwarded - it is up to the auth_interface
-	// implementation what to do with it.
-	mock_auth auth;
-	auth.result = nullptr;
-	auto* p = parse_http_auth(make_request("Bearer sometoken"), auth);
-	BOOST_TEST(p == nullptr);
-	BOOST_TEST(auth.authenticate_called);
-	BOOST_TEST(auth.last_authorization == "Bearer sometoken");
-	BOOST_TEST(auth.last_user == "");
-	BOOST_TEST(auth.last_password == "");
-}
-
-BOOST_AUTO_TEST_CASE(basic_capital_b)
-{
-	// "Basic" with capital B: the scheme check is case-insensitive.
-	mock_auth auth;
-	auth.result = nullptr;
-	(void)parse_http_auth(make_request("Basic dXNlcjpwYXNz"), auth);
-	BOOST_TEST(auth.last_user == "user");
-	BOOST_TEST(auth.last_password == "pass");
-}
-
-BOOST_AUTO_TEST_CASE(basic_mixed_case)
-{
-	// "basic" is case insensitive
-	mock_auth auth;
-	auth.result = nullptr;
-	(void)parse_http_auth(make_request("BaSiC dXNlcjpwYXNz"), auth);
-	BOOST_TEST(auth.last_user == "user");
-	BOOST_TEST(auth.last_password == "pass");
-}
-
-BOOST_AUTO_TEST_CASE(rejected_credentials)
-{
-	// Auth rejects the credentials: authenticate returns nullptr, propagated.
-	mock_auth auth;
-	auth.result = nullptr;
-	auto* p = parse_http_auth(make_request("basic dXNlcjpwYXNz"), auth);
-	BOOST_TEST(p == nullptr);
-	BOOST_TEST(auth.last_user == "user");
-	BOOST_TEST(auth.last_password == "pass");
-}
-
 BOOST_AUTO_TEST_CASE(session_cookie_extracted)
 {
 	// A "session=<value>" cookie is pulled out of the Cookie header.
@@ -190,7 +58,6 @@ BOOST_AUTO_TEST_CASE(session_cookie_extracted)
 	auth.result = &g_full;
 	(void)parse_http_auth(make_request(nullptr, "session=abc123"), auth);
 	BOOST_TEST(auth.last_cookie == "abc123");
-	BOOST_TEST(auth.last_authorization == "");
 }
 
 BOOST_AUTO_TEST_CASE(session_cookie_among_others)
@@ -210,18 +77,6 @@ BOOST_AUTO_TEST_CASE(no_session_cookie)
 	auth.result = nullptr;
 	(void)parse_http_auth(make_request(nullptr, "theme=dark; lang=en"), auth);
 	BOOST_TEST(auth.last_cookie == "");
-}
-
-BOOST_AUTO_TEST_CASE(both_headers_forwarded)
-{
-	// When both headers are present, both are passed to authenticate().
-	mock_auth auth;
-	auth.result = &g_full;
-	(void)parse_http_auth(make_request("basic dXNlcjpwYXNz", "session=abc"), auth);
-	BOOST_TEST(auth.last_cookie == "abc");
-	BOOST_TEST(auth.last_authorization == "basic dXNlcjpwYXNz");
-	BOOST_TEST(auth.last_user == "user");
-	BOOST_TEST(auth.last_password == "pass");
 }
 
 // ---------- extract_cookie ----------


### PR DESCRIPTION
Last nail in the coffin for HTTP basic auth, remove remnants from auth_interface