### PR TITLE
Reduce piece history update allocations

### DIFF
--- a/src/piece_history.cpp
+++ b/src/piece_history.cpp
@@ -9,7 +9,7 @@ see LICENSE file.
 
 #include "piece_history.hpp"
 #include <algorithm>
-#include <set>
+#include <vector>
 
 namespace ltweb {
 
@@ -23,20 +23,27 @@ frame_t piece_history::update(std::vector<lt::partial_piece_info> const& pieces)
 {
 	frame_t const frame = ++m_frame;
 
-	// Build the set of incoming piece indices.
-	std::set<lt::piece_index_t> incoming;
+	std::vector<lt::piece_index_t> incoming;
+	incoming.reserve(pieces.size());
 	for (auto const& p : pieces)
-		incoming.insert(p.piece_index);
+		incoming.push_back(p.piece_index);
+	std::sort(incoming.begin(), incoming.end());
+	incoming.erase(std::unique(incoming.begin(), incoming.end()), incoming.end());
 
 	// Remove pieces that are no longer in the download queue.
+	auto incoming_it = incoming.begin();
 	for (auto it = m_pieces.begin(); it != m_pieces.end();) {
-		if (incoming.count(it->first) == 0) {
+		incoming_it = std::lower_bound(incoming_it, incoming.end(), it->first);
+		if (incoming_it == incoming.end() || *incoming_it != it->first) {
 			m_removed.push_front({frame, it->second.added_frame, it->first});
 			it = m_pieces.erase(it);
 		} else {
+			++incoming_it;
 			++it;
 		}
 	}
+
+	std::vector<lt::piece_index_t> inserted_pieces;
 
 	// Add or update pieces.
 	for (auto const& p : pieces) {
@@ -49,13 +56,7 @@ frame_t piece_history::update(std::vector<lt::partial_piece_info> const& pieces)
 			entry.blocks.resize(p.blocks_in_piece);
 			for (int i = 0; i < p.blocks_in_piece; ++i)
 				entry.blocks[i] = {std::uint8_t(p.blocks[i].state), frame};
-
-			// If this piece re-appeared after removal, clean it from m_removed.
-			auto const rem_end =
-				std::remove_if(m_removed.begin(), m_removed.end(), [&](auto const& r) {
-					return r.piece_index == p.piece_index;
-				});
-			m_removed.erase(rem_end, m_removed.end());
+			if (!m_removed.empty()) inserted_pieces.push_back(p.piece_index);
 		} else {
 			// Grow the block array if the piece reports more blocks than stored
 			// (shouldn't normally happen, but be defensive).
@@ -67,6 +68,19 @@ frame_t piece_history::update(std::vector<lt::partial_piece_info> const& pieces)
 				if (entry.blocks[i].state != new_state) entry.blocks[i] = {new_state, frame};
 			}
 		}
+	}
+
+	if (!inserted_pieces.empty()) {
+		std::sort(inserted_pieces.begin(), inserted_pieces.end());
+		inserted_pieces.erase(
+			std::unique(inserted_pieces.begin(), inserted_pieces.end()), inserted_pieces.end()
+		);
+		auto const rem_end = std::remove_if(m_removed.begin(), m_removed.end(), [&](auto const& r) {
+			return std::binary_search(
+				inserted_pieces.begin(), inserted_pieces.end(), r.piece_index
+			);
+		});
+		m_removed.erase(rem_end, m_removed.end());
 	}
 
 	// Evict oldest tombstones when over the limit (deque is newest-first).

--- a/src/piece_history.cpp
+++ b/src/piece_history.cpp
@@ -33,7 +33,8 @@ frame_t piece_history::update(std::vector<lt::partial_piece_info> const& pieces)
 	// Remove pieces that are no longer in the download queue.
 	auto incoming_it = incoming.begin();
 	for (auto it = m_pieces.begin(); it != m_pieces.end();) {
-		while (incoming_it != incoming.end() && *incoming_it < it->first) ++incoming_it;
+		while (incoming_it != incoming.end() && *incoming_it < it->first)
+			++incoming_it;
 		if (incoming_it == incoming.end() || *incoming_it != it->first) {
 			m_removed.push_front({frame, it->second.added_frame, it->first});
 			it = m_pieces.erase(it);

--- a/src/piece_history.cpp
+++ b/src/piece_history.cpp
@@ -33,7 +33,7 @@ frame_t piece_history::update(std::vector<lt::partial_piece_info> const& pieces)
 	// Remove pieces that are no longer in the download queue.
 	auto incoming_it = incoming.begin();
 	for (auto it = m_pieces.begin(); it != m_pieces.end();) {
-		incoming_it = std::lower_bound(incoming_it, incoming.end(), it->first);
+		while (incoming_it != incoming.end() && *incoming_it < it->first) ++incoming_it;
 		if (incoming_it == incoming.end() || *incoming_it != it->first) {
 			m_removed.push_front({frame, it->second.added_frame, it->first});
 			it = m_pieces.erase(it);
@@ -44,6 +44,7 @@ frame_t piece_history::update(std::vector<lt::partial_piece_info> const& pieces)
 	}
 
 	std::vector<lt::piece_index_t> inserted_pieces;
+	if (!m_removed.empty()) inserted_pieces.reserve(pieces.size());
 
 	// Add or update pieces.
 	for (auto const& p : pieces) {


### PR DESCRIPTION
Reduces allocation churn in piece_history::update().

This uses sorted vectors instead of building a std::set for each incoming piece snapshot, and batches tombstone cleanup for re-added pieces into one pass.

I do not have a benchmark number for this, so the intended win is fewer per-update allocations and less repeated tombstone scanning.

Validation:
git diff --check
b2 toolset=darwin test_piece_history
b2 toolset=darwin
