### PR TITLE
Track open file modes sparsely

### DIFF
--- a/src/file_history.cpp
+++ b/src/file_history.cpp
@@ -8,9 +8,17 @@ see LICENSE file.
 */
 
 #include "file_history.hpp"
-#include <unordered_map>
+#include <algorithm>
 
 namespace ltweb {
+namespace {
+
+struct open_file_entry {
+	int file_index;
+	std::uint8_t open_mode;
+};
+
+} // anonymous namespace
 
 file_history::file_history(lt::sha1_hash const& ih, lt::file_storage const& fs)
 	: m_ih(ih)
@@ -45,25 +53,72 @@ frame_t file_history::update(
 		}
 	}
 
-	if (open_modes != nullptr) {
-		// open_modes is sparse: only currently-open files appear.
-		// Build a dense lookup for this update round.
-		std::unordered_map<int, std::uint8_t> om;
-		om.reserve(open_modes->size());
-		for (auto const& s : *open_modes)
-			om[static_cast<int>(s.file_index)] = static_cast<std::uint8_t>(s.open_mode);
-
-		for (int fi = 0; fi < n; ++fi) {
-			auto const it = om.find(fi);
-			std::uint8_t const new_mode = (it != om.end()) ? it->second : std::uint8_t(0);
-			if (new_mode != m_files[fi].open_mode) {
-				m_files[fi].open_mode = new_mode;
-				m_files[fi].open_mode_frame = frame;
-			}
-		}
-	}
+	if (open_modes != nullptr) update_open_modes(*open_modes, frame);
 
 	return frame;
+}
+
+void file_history::update_open_modes(
+	std::vector<lt::open_file_state> const& open_modes,
+	frame_t const frame
+)
+{
+	int const n = static_cast<int>(m_files.size());
+	std::vector<open_file_entry> current;
+	current.reserve(open_modes.size());
+
+	for (auto const& s : open_modes) {
+		int const fi = static_cast<int>(s.file_index);
+		if (fi < 0 || fi >= n) continue;
+		current.push_back({fi, static_cast<std::uint8_t>(s.open_mode)});
+	}
+
+	std::stable_sort(current.begin(), current.end(), [](auto const& lhs, auto const& rhs) {
+		return lhs.file_index < rhs.file_index;
+	});
+
+	auto out = current.begin();
+	for (auto it = current.begin(); it != current.end();) {
+		int const fi = it->file_index;
+		std::uint8_t mode = it->open_mode;
+		for (++it; it != current.end() && it->file_index == fi; ++it)
+			mode = it->open_mode;
+		*out++ = {fi, mode};
+	}
+	current.erase(out, current.end());
+
+	std::vector<int> next_open_files;
+	next_open_files.reserve(current.size());
+
+	auto old = m_open_files.begin();
+	auto cur = current.begin();
+	while (old != m_open_files.end() || cur != current.end()) {
+		int file_index;
+		std::uint8_t new_mode;
+
+		if (old == m_open_files.end() || (cur != current.end() && cur->file_index < *old)) {
+			file_index = cur->file_index;
+			new_mode = cur->open_mode;
+			++cur;
+		} else if (cur == current.end() || *old < cur->file_index) {
+			file_index = *old;
+			new_mode = 0;
+			++old;
+		} else {
+			file_index = *old;
+			new_mode = cur->open_mode;
+			++old;
+			++cur;
+		}
+
+		if (m_files[file_index].open_mode != new_mode) {
+			m_files[file_index].open_mode = new_mode;
+			m_files[file_index].open_mode_frame = frame;
+		}
+		if (new_mode != 0) next_open_files.push_back(file_index);
+	}
+
+	m_open_files.swap(next_open_files);
 }
 
 std::vector<std::uint16_t>

--- a/src/file_history.cpp
+++ b/src/file_history.cpp
@@ -59,8 +59,7 @@ frame_t file_history::update(
 }
 
 void file_history::update_open_modes(
-	std::vector<lt::open_file_state> const& open_modes,
-	frame_t const frame
+	std::vector<lt::open_file_state> const& open_modes, frame_t const frame
 )
 {
 	int const n = static_cast<int>(m_files.size());

--- a/src/file_history.hpp
+++ b/src/file_history.hpp
@@ -73,9 +73,12 @@ struct file_history {
 	std::uint8_t open_mode(int fi) const { return m_files[fi].open_mode; }
 
 private:
+	void update_open_modes(std::vector<lt::open_file_state> const& open_modes, frame_t frame);
+
 	lt::sha1_hash const m_ih;
 	frame_t m_frame = 1;
 	std::vector<file_history_entry> m_files; // indexed by file_index
+	std::vector<int> m_open_files; // sorted currently-open file indices
 };
 
 } // namespace ltweb

--- a/tests/test_file_history.cpp
+++ b/tests/test_file_history.cpp
@@ -226,6 +226,30 @@ BOOST_AUTO_TEST_CASE(open_mode_accessor_after_close)
 	BOOST_TEST(fh.open_mode(0) == 0u);
 }
 
+BOOST_AUTO_TEST_CASE(open_mode_duplicate_entries_use_last_value)
+{
+	auto const fs = make_fs(1);
+	ltweb::file_history fh(make_hash(0x11), fs);
+
+	std::vector<lt::open_file_state> om = {make_open(0, 0x02), make_open(0, 0x06)};
+	fh.update(nullptr, nullptr, &om);
+
+	BOOST_TEST(fh.open_mode(0) == 0x06u);
+}
+
+BOOST_AUTO_TEST_CASE(open_mode_invalid_entries_ignored)
+{
+	auto const fs = make_fs(1);
+	ltweb::file_history fh(make_hash(0x11), fs);
+
+	std::vector<lt::open_file_state> om = {make_open(-1, 0x02), make_open(1, 0x04)};
+	ltweb::frame_t const f1 = fh.update(nullptr, nullptr, &om);
+
+	BOOST_TEST(fh.open_mode(0) == 0u);
+	auto const masks = fh.query(f1, 0x20u);
+	BOOST_TEST(masks[0] == 0u);
+}
+
 // Value accessors return the values last passed to update().
 BOOST_AUTO_TEST_CASE(accessors_return_updated_values)
 {


### PR DESCRIPTION
Avoids scanning every file when updating sparse open-file state.

file_status() only reports currently open files, so file_history now keeps the previous open-file set and merges it with the current one. This still reports close transitions, but avoids the dense open-mode pass for torrents with many files and few open files.

Validation:
git diff --check
b2 toolset=darwin test_file_history
b2 toolset=darwin
